### PR TITLE
feat: add ecs-express-deploy reusable workflow

### DIFF
--- a/.github/workflows/ecs-express-deploy.yml
+++ b/.github/workflows/ecs-express-deploy.yml
@@ -1,0 +1,179 @@
+name: Reusable ECS Express Mode Deploy
+
+on:
+  workflow_call:
+    inputs:
+      service-name:
+        description: 'ECS Express service name'
+        required: true
+        type: string
+      image:
+        description: 'Full container image URI (e.g. 123.dkr.ecr.us-east-1.amazonaws.com/app:v1.2.3)'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS region'
+        required: false
+        type: string
+        default: 'us-east-1'
+      cluster:
+        description: 'ECS cluster name (Express Mode creates one if omitted)'
+        required: false
+        type: string
+        default: ''
+      container-port:
+        description: 'Container port that receives traffic'
+        required: false
+        type: number
+        default: 80
+      cpu:
+        description: 'Fargate CPU units (e.g. 256, 512, 1024, 2048, 4096)'
+        required: false
+        type: string
+        default: '512'
+      memory:
+        description: 'Fargate memory in MiB (e.g. 1024, 2048, 4096)'
+        required: false
+        type: string
+        default: '1024'
+      environment-variables:
+        description: 'JSON array of env vars: [{"name":"K","value":"V"}]'
+        required: false
+        type: string
+        default: ''
+      secrets-json:
+        description: 'JSON array of secrets: [{"name":"K","valueFrom":"arn:..."}]'
+        required: false
+        type: string
+        default: ''
+      command:
+        description: 'Container command override as JSON array (e.g. ["node","server.js"])'
+        required: false
+        type: string
+        default: ''
+      health-check-path:
+        description: 'ALB health-check path'
+        required: false
+        type: string
+        default: '/'
+      min-task-count:
+        description: 'Minimum running tasks'
+        required: false
+        type: number
+        default: 1
+      max-task-count:
+        description: 'Maximum running tasks (auto-scaling ceiling)'
+        required: false
+        type: number
+        default: 3
+      auto-scaling-metric:
+        description: 'Auto-scaling metric (AVERAGE_CPU, AVERAGE_MEMORY, REQUEST_COUNT_PER_TASK)'
+        required: false
+        type: string
+        default: 'AVERAGE_CPU'
+      auto-scaling-target-value:
+        description: 'Auto-scaling target value'
+        required: false
+        type: number
+        default: 70
+      subnets:
+        description: 'Comma-separated subnet IDs (omit to use the default VPC)'
+        required: false
+        type: string
+        default: ''
+      security-groups:
+        description: 'Comma-separated security group IDs'
+        required: false
+        type: string
+        default: ''
+      task-role-arn:
+        description: 'IAM role ARN for the running container (app permissions)'
+        required: false
+        type: string
+        default: ''
+      tags:
+        description: 'JSON array of resource tags: [{"key":"K","value":"V"}]'
+        required: false
+        type: string
+        default: ''
+      checkout-ref:
+        description: 'Git ref to checkout (defaults to triggering ref)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      role-arn:
+        description: 'IAM role ARN for AWS authentication via OIDC'
+        required: true
+      execution-role-arn:
+        description: 'ECS task execution role ARN (pulls image, writes logs)'
+        required: true
+      infrastructure-role-arn:
+        description: 'ECS infrastructure role ARN (manages ALB/target groups/SGs)'
+        required: true
+    outputs:
+      service-arn:
+        description: 'ARN of the deployed Express service'
+        value: ${{ jobs.deploy.outputs.service-arn }}
+      endpoint:
+        description: 'Public endpoint URL (ALB DNS name)'
+        value: ${{ jobs.deploy.outputs.endpoint }}
+
+concurrency:
+  group: ecs-express-${{ inputs.service-name }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to ECS Express
+    runs-on: ubuntu-latest
+    outputs:
+      service-arn: ${{ steps.deploy.outputs.service-arn }}
+      endpoint: ${{ steps.deploy.outputs.endpoint }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Deploy to ECS Express Mode
+        id: deploy
+        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        with:
+          service-name: ${{ inputs.service-name }}
+          image: ${{ inputs.image }}
+          execution-role-arn: ${{ secrets.execution-role-arn }}
+          infrastructure-role-arn: ${{ secrets.infrastructure-role-arn }}
+          cluster: ${{ inputs.cluster }}
+          container-port: ${{ inputs.container-port }}
+          cpu: ${{ inputs.cpu }}
+          memory: ${{ inputs.memory }}
+          environment-variables: ${{ inputs.environment-variables }}
+          secrets: ${{ inputs.secrets-json }}
+          command: ${{ inputs.command }}
+          health-check-path: ${{ inputs.health-check-path }}
+          min-task-count: ${{ inputs.min-task-count }}
+          max-task-count: ${{ inputs.max-task-count }}
+          auto-scaling-metric: ${{ inputs.auto-scaling-metric }}
+          auto-scaling-target-value: ${{ inputs.auto-scaling-target-value }}
+          subnets: ${{ inputs.subnets }}
+          security-groups: ${{ inputs.security-groups }}
+          task-role-arn: ${{ inputs.task-role-arn }}
+          tags: ${{ inputs.tags }}
+
+      - name: Summarize deployment
+        run: |
+          echo "### ECS Express deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Service:** \`${{ inputs.service-name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image:** \`${{ inputs.image }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Endpoint:** ${{ steps.deploy.outputs.endpoint }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **ARN:** \`${{ steps.deploy.outputs.service-arn }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Commitlint](https://img.shields.io/badge/workflow-commitlint-blue?logo=conventionalcommits&logoColor=white)](#commitlint)
 [![Docker GHCR](https://img.shields.io/badge/workflow-docker--ghcr-blue?logo=docker&logoColor=white)](#docker-build--push-to-ghcr)
 [![CDK Deploy](https://img.shields.io/badge/workflow-cdk--deploy-blue?logo=amazonaws&logoColor=white)](#cdk-deploy)
+[![ECS Express](https://img.shields.io/badge/workflow-ecs--express-blue?logo=amazonaws&logoColor=white)](#ecs-express-deploy)
 [![AI Release](https://img.shields.io/badge/workflow-release-blue?logo=anthropic&logoColor=white)](#ai-powered-release)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
@@ -100,6 +101,61 @@ jobs:
 |--------|----------|-------------|
 | `role-arn` | yes | ARN of the IAM role to assume via OIDC |
 
+### ECS Express Deploy
+
+**`ecs-express-deploy.yml`** — Deploy a container image to [Amazon ECS Express Mode](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/express-service-overview.html) (launched Nov 2025). Express Mode auto-provisions the Fargate service, ALB, target groups, security groups, and auto-scaling — you supply an image and two IAM roles.
+
+```yaml
+jobs:
+  deploy:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/ecs-express-deploy.yml@main
+    with:
+      service-name: my-app
+      image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-app:v1.2.3
+      container-port: 3000
+      health-check-path: /api/health
+    secrets:
+      role-arn: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      execution-role-arn: ${{ secrets.ECS_EXECUTION_ROLE_ARN }}
+      infrastructure-role-arn: ${{ secrets.ECS_INFRASTRUCTURE_ROLE_ARN }}
+```
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `service-name` | string | — | ECS Express service name (required) |
+| `image` | string | — | Full container image URI (required) |
+| `aws-region` | string | `us-east-1` | AWS region |
+| `cluster` | string | | Existing cluster name (Express Mode creates one if omitted) |
+| `container-port` | number | `80` | Port the container listens on |
+| `cpu` | string | `512` | Fargate CPU units |
+| `memory` | string | `1024` | Fargate memory in MiB |
+| `environment-variables` | string | | JSON array `[{"name":"K","value":"V"}]` |
+| `secrets-json` | string | | JSON array `[{"name":"K","valueFrom":"arn:..."}]` |
+| `command` | string | | Container command override as JSON array |
+| `health-check-path` | string | `/` | ALB health-check path |
+| `min-task-count` | number | `1` | Auto-scaling floor |
+| `max-task-count` | number | `3` | Auto-scaling ceiling |
+| `auto-scaling-metric` | string | `AVERAGE_CPU` | `AVERAGE_CPU`, `AVERAGE_MEMORY`, or `REQUEST_COUNT_PER_TASK` |
+| `auto-scaling-target-value` | number | `70` | Target value for the chosen metric |
+| `subnets` | string | | Comma-separated subnet IDs (omit to use default VPC) |
+| `security-groups` | string | | Comma-separated SG IDs |
+| `task-role-arn` | string | | App-level IAM role for the running container |
+| `tags` | string | | JSON array `[{"key":"K","value":"V"}]` |
+| `checkout-ref` | string | | Git ref to check out (defaults to triggering ref) |
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `role-arn` | yes | OIDC role for the GitHub runner to call ECS APIs |
+| `execution-role-arn` | yes | ECS task execution role (pulls image, writes logs) |
+| `infrastructure-role-arn` | yes | ECS infra role (creates ALB / target groups / SGs) |
+
+| Output | Description |
+|--------|-------------|
+| `service-arn` | ARN of the deployed Express service |
+| `endpoint` | Public endpoint URL (ALB DNS name) |
+
+> **Versioning:** pair with `semver-tag.yml` → `docker-ghcr.yml` (with `version:`) → `actions/ecr-mirror` → this workflow. See [`examples/ecs-express.yml`](examples/ecs-express.yml).
+
 ### AI-Powered Release
 
 **`release.yml`** — Create a GitHub Release with a Claude-generated title and summary when a semver tag is pushed.
@@ -145,7 +201,32 @@ gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
 
 # For CDK deployments (cdk-deploy.yml)
 gh secret set AWS_DEPLOY_ROLE_ARN --repo <owner>/<repo>
+
+# For ECS Express deployments (ecs-express-deploy.yml)
+gh secret set AWS_DEPLOY_ROLE_ARN --repo <owner>/<repo>
+gh secret set ECS_EXECUTION_ROLE_ARN --repo <owner>/<repo>
+gh secret set ECS_INFRASTRUCTURE_ROLE_ARN --repo <owner>/<repo>
 ```
+
+### ECS Express IAM bootstrap (one-time per AWS account)
+
+ECS Express Mode needs two task-level IAM roles in addition to the OIDC deploy role. Create them once per account:
+
+```bash
+# Execution role — pulls images, writes logs
+aws iam create-role --role-name ecsTaskExecutionRole \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+aws iam attach-role-policy --role-name ecsTaskExecutionRole \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+# Infrastructure role — manages ALB/target groups/security groups for Express services
+aws iam create-role --role-name ecsInfrastructureRole \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+aws iam attach-role-policy --role-name ecsInfrastructureRole \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSInfrastructureRolePolicyForLoadBalancers
+```
+
+Store both ARNs as repo secrets (`ECS_EXECUTION_ROLE_ARN`, `ECS_INFRASTRUCTURE_ROLE_ARN`). The deploy OIDC role (`AWS_DEPLOY_ROLE_ARN`) needs `ecs:*`, `iam:PassRole` for the two roles above, `elasticloadbalancing:*`, `ec2:Describe*`, `logs:*`, and `application-autoscaling:*`.
 
 Generate your Anthropic API key at [console.anthropic.com](https://console.anthropic.com/) under API Keys.
 
@@ -165,6 +246,7 @@ See [`examples/`](examples/) for ready-to-copy workflow files:
 
 - [`ci.yml`](examples/ci.yml) — Build verification + Docker push + commitlint
 - [`release.yml`](examples/release.yml) — AI-powered release on tag push
+- [`ecs-express.yml`](examples/ecs-express.yml) — Tag-driven release pipeline: semver-tag → docker-ghcr → ecr-mirror → ECS Express deploy
 
 ## License
 

--- a/examples/ecs-express.yml
+++ b/examples/ecs-express.yml
@@ -1,0 +1,71 @@
+# Example: tag-driven release pipeline for a containerized app deployed to ECS Express Mode.
+#
+# Flow on push to main:
+#   1. semver-tag    — bumps version from conventional commits, creates vX.Y.Z tag
+#   2. docker-ghcr   — builds image, pushes to ghcr.io tagged with the new version
+#   3. mirror        — mirrors the ghcr image into a private ECR repo
+#   4. deploy        — ecs-express-deploy points the service at the new ECR image
+#   5. release       — AI-generated GitHub Release (fires on the tag push)
+#
+# The release workflow runs separately on the `v*` tag push created by semver-tag.
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write       # semver-tag needs to push tags
+  packages: write       # docker-ghcr needs to push to ghcr.io
+  id-token: write       # OIDC for AWS
+
+jobs:
+  version:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/semver-tag.yml@main
+    with:
+      default-bump: 'patch'
+
+  image:
+    needs: version
+    if: needs.version.outputs.bumped == 'true'
+    uses: KotaHusky/cicd-toolkit/.github/workflows/docker-ghcr.yml@main
+    with:
+      version: ${{ needs.version.outputs.new-version }}
+
+  mirror:
+    needs: [version, image]
+    if: needs.version.outputs.bumped == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      ecr-image: ${{ steps.mirror.outputs.ecr-image }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+      - id: mirror
+        uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@v2
+        with:
+          source-image: ghcr.io/${{ github.repository }}:v${{ needs.version.outputs.new-version }}
+          ecr-tag: v${{ needs.version.outputs.new-version }}
+          aws-region: us-east-1
+
+  deploy:
+    needs: [version, mirror]
+    if: needs.version.outputs.bumped == 'true'
+    uses: KotaHusky/cicd-toolkit/.github/workflows/ecs-express-deploy.yml@main
+    with:
+      service-name: my-app
+      image: ${{ needs.mirror.outputs.ecr-image }}
+      aws-region: us-east-1
+      container-port: 3000
+      health-check-path: /api/health
+    secrets:
+      role-arn: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      execution-role-arn: ${{ secrets.ECS_EXECUTION_ROLE_ARN }}
+      infrastructure-role-arn: ${{ secrets.ECS_INFRASTRUCTURE_ROLE_ARN }}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ecs-express-deploy.yml` — reusable workflow wrapping `aws-actions/amazon-ecs-deploy-express-service@v1` for [Amazon ECS Express Mode](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/express-service-overview.html) (launched Nov 2025; AWS-recommended migration target for App Runner).
- Takes a pre-built image URI plus the two required IAM role ARNs (execution + infrastructure) and forwards them to the action. Outputs `service-arn` and `endpoint`. Concurrency keyed per `service-name`.
- Add `examples/ecs-express.yml` showing the tag-driven release pipeline: `semver-tag` → `docker-ghcr` (versioned) → `ecr-mirror` → `ecs-express-deploy`. Versioning behavior unchanged.
- README updated with the new workflow section, IAM bootstrap commands, and required secrets.

First consumer is `br-kiosk-webapp` (separate PR).

## Test plan

- [ ] Workflow YAML validates (locally confirmed with `yaml.safe_load`).
- [ ] First real consumer deploy from `br-kiosk-webapp` succeeds end-to-end on a push to `main`.
- [ ] Verify ECS service comes up and ALB endpoint returns 200 on `/api/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)