### PR TITLE
fix(static-s3-deploy): avoid multiline objects-uploaded output

### DIFF
--- a/.github/workflows/static-s3-deploy.yml
+++ b/.github/workflows/static-s3-deploy.yml
@@ -159,7 +159,11 @@ jobs:
               --cache-control "public, max-age=31536000, immutable"
           fi
 
-          COUNT=$(grep -cE '^(upload|copy):' /tmp/sync.log || echo 0)
+          # `grep -c` exits 1 on no-match AND prints `0`; chaining `|| echo 0`
+          # then double-printed it, producing a multiline value that
+          # $GITHUB_OUTPUT rejects ("Invalid format '0'"). `wc -l` on the
+          # filtered stream always exits 0 and always emits a single integer.
+          COUNT=$(grep -E '^(upload|copy):' /tmp/sync.log | wc -l | tr -d ' ')
           echo "objects-uploaded=${COUNT}" >> "$GITHUB_OUTPUT"
 
       - name: Invalidate CloudFront cache


### PR DESCRIPTION
Hit on the first real deploy from `Barks-Rec/br-kiosk-webapp`. The s3 sync uploaded ~30 objects successfully, then the workflow failed with `Invalid format '0'` writing the `objects-uploaded` output. `grep -c ... || echo 0` double-prints `0` on no-match, producing a multiline value that $GITHUB_OUTPUT rejects.

Replaced with `grep -E ... | wc -l` which always exits 0 and always emits a single integer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)