### PR TITLE
feat(workflows): add ecs-express-deploy reusable workflow

### DIFF
--- a/.github/workflows/ecs-express-deploy.yml
+++ b/.github/workflows/ecs-express-deploy.yml
@@ -1,0 +1,179 @@
+name: Reusable ECS Express Mode Deploy
+
+on:
+  workflow_call:
+    inputs:
+      service-name:
+        description: 'ECS Express service name'
+        required: true
+        type: string
+      image:
+        description: 'Full container image URI (e.g. 123.dkr.ecr.us-east-1.amazonaws.com/app:v1.2.3)'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS region'
+        required: false
+        type: string
+        default: 'us-east-1'
+      cluster:
+        description: 'ECS cluster name (Express Mode creates one if omitted)'
+        required: false
+        type: string
+        default: ''
+      container-port:
+        description: 'Container port that receives traffic'
+        required: false
+        type: number
+        default: 80
+      cpu:
+        description: 'Fargate CPU units (e.g. 256, 512, 1024, 2048, 4096)'
+        required: false
+        type: string
+        default: '512'
+      memory:
+        description: 'Fargate memory in MiB (e.g. 1024, 2048, 4096)'
+        required: false
+        type: string
+        default: '1024'
+      environment-variables:
+        description: 'JSON array of env vars: [{"name":"K","value":"V"}]'
+        required: false
+        type: string
+        default: ''
+      secrets-json:
+        description: 'JSON array of secrets: [{"name":"K","valueFrom":"arn:..."}]'
+        required: false
+        type: string
+        default: ''
+      command:
+        description: 'Container command override as JSON array (e.g. ["node","server.js"])'
+        required: false
+        type: string
+        default: ''
+      health-check-path:
+        description: 'ALB health-check path'
+        required: false
+        type: string
+        default: '/'
+      min-task-count:
+        description: 'Minimum running tasks'
+        required: false
+        type: number
+        default: 1
+      max-task-count:
+        description: 'Maximum running tasks (auto-scaling ceiling)'
+        required: false
+        type: number
+        default: 3
+      auto-scaling-metric:
+        description: 'Auto-scaling metric (AVERAGE_CPU, AVERAGE_MEMORY, REQUEST_COUNT_PER_TASK)'
+        required: false
+        type: string
+        default: 'AVERAGE_CPU'
+      auto-scaling-target-value:
+        description: 'Auto-scaling target value'
+        required: false
+        type: number
+        default: 70
+      subnets:
+        description: 'Comma-separated subnet IDs (omit to use the default VPC)'
+        required: false
+        type: string
+        default: ''
+      security-groups:
+        description: 'Comma-separated security group IDs'
+        required: false
+        type: string
+        default: ''
+      task-role-arn:
+        description: 'IAM role ARN for the running container (app permissions)'
+        required: false
+        type: string
+        default: ''
+      tags:
+        description: 'JSON array of resource tags: [{"key":"K","value":"V"}]'
+        required: false
+        type: string
+        default: ''
+      checkout-ref:
+        description: 'Git ref to checkout (defaults to triggering ref)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      role-arn:
+        description: 'IAM role ARN for AWS authentication via OIDC'
+        required: true
+      execution-role-arn:
+        description: 'ECS task execution role ARN (pulls image, writes logs)'
+        required: true
+      infrastructure-role-arn:
+        description: 'ECS infrastructure role ARN (manages ALB/target groups/SGs)'
+        required: true
+    outputs:
+      service-arn:
+        description: 'ARN of the deployed Express service'
+        value: ${{ jobs.deploy.outputs.service-arn }}
+      endpoint:
+        description: 'Public endpoint URL (ALB DNS name)'
+        value: ${{ jobs.deploy.outputs.endpoint }}
+
+concurrency:
+  group: ecs-express-${{ inputs.service-name }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to ECS Express
+    runs-on: ubuntu-latest
+    outputs:
+      service-arn: ${{ steps.deploy.outputs.service-arn }}
+      endpoint: ${{ steps.deploy.outputs.endpoint }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Deploy to ECS Express Mode
+        id: deploy
+        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        with:
+          service-name: ${{ inputs.service-name }}
+          image: ${{ inputs.image }}
+          execution-role-arn: ${{ secrets.execution-role-arn }}
+          infrastructure-role-arn: ${{ secrets.infrastructure-role-arn }}
+          cluster: ${{ inputs.cluster }}
+          container-port: ${{ inputs.container-port }}
+          cpu: ${{ inputs.cpu }}
+          memory: ${{ inputs.memory }}
+          environment-variables: ${{ inputs.environment-variables }}
+          secrets: ${{ inputs.secrets-json }}
+          command: ${{ inputs.command }}
+          health-check-path: ${{ inputs.health-check-path }}
+          min-task-count: ${{ inputs.min-task-count }}
+          max-task-count: ${{ inputs.max-task-count }}
+          auto-scaling-metric: ${{ inputs.auto-scaling-metric }}
+          auto-scaling-target-value: ${{ inputs.auto-scaling-target-value }}
+          subnets: ${{ inputs.subnets }}
+          security-groups: ${{ inputs.security-groups }}
+          task-role-arn: ${{ inputs.task-role-arn }}
+          tags: ${{ inputs.tags }}
+
+      - name: Summarize deployment
+        run: |
+          echo "### ECS Express deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Service:** \`${{ inputs.service-name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image:** \`${{ inputs.image }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Endpoint:** ${{ steps.deploy.outputs.endpoint }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **ARN:** \`${{ steps.deploy.outputs.service-arn }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/examples/ecs-express.yml
+++ b/examples/ecs-express.yml
@@ -1,0 +1,71 @@
+# Example: tag-driven release pipeline for a containerized app deployed to ECS Express Mode.
+#
+# Flow on push to main:
+#   1. semver-tag    — bumps version from conventional commits, creates vX.Y.Z tag
+#   2. docker-ghcr   — builds image, pushes to ghcr.io tagged with the new version
+#   3. mirror        — mirrors the ghcr image into a private ECR repo
+#   4. deploy        — ecs-express-deploy points the service at the new ECR image
+#   5. release       — AI-generated GitHub Release (fires on the tag push)
+#
+# The release workflow runs separately on the `v*` tag push created by semver-tag.
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write       # semver-tag needs to push tags
+  packages: write       # docker-ghcr needs to push to ghcr.io
+  id-token: write       # OIDC for AWS
+
+jobs:
+  version:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/semver-tag.yml@main
+    with:
+      default-bump: 'patch'
+
+  image:
+    needs: version
+    if: needs.version.outputs.bumped == 'true'
+    uses: KotaHusky/cicd-toolkit/.github/workflows/docker-ghcr.yml@main
+    with:
+      version: ${{ needs.version.outputs.new-version }}
+
+  mirror:
+    needs: [version, image]
+    if: needs.version.outputs.bumped == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      ecr-image: ${{ steps.mirror.outputs.ecr-image }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+      - id: mirror
+        uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@v2
+        with:
+          source-image: ghcr.io/${{ github.repository }}:v${{ needs.version.outputs.new-version }}
+          ecr-tag: v${{ needs.version.outputs.new-version }}
+          aws-region: us-east-1
+
+  deploy:
+    needs: [version, mirror]
+    if: needs.version.outputs.bumped == 'true'
+    uses: KotaHusky/cicd-toolkit/.github/workflows/ecs-express-deploy.yml@main
+    with:
+      service-name: my-app
+      image: ${{ needs.mirror.outputs.ecr-image }}
+      aws-region: us-east-1
+      container-port: 3000
+      health-check-path: /api/health
+    secrets:
+      role-arn: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      execution-role-arn: ${{ secrets.ECS_EXECUTION_ROLE_ARN }}
+      infrastructure-role-arn: ${{ secrets.ECS_INFRASTRUCTURE_ROLE_ARN }}


### PR DESCRIPTION
Adds `ecs-express-deploy.yml` (+ example) to main. The homepage apps' `deploy-aws.yml` reference it `@main` but it only existed on the stale `feat/ecs-express` branch (PR #26), which predates the edge-stack work and would revert it if merged. Cherry-picked just the self-contained workflow onto current main instead.

Closes the gap that made `gh workflow run deploy-aws.yml` fail with 'workflow was not found'. Supersedes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)