### PR TITLE
feat: opt-in tiered observability on EcsExpressEdgeStack

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,3 +16,11 @@ export { OidcBootstrapStack, OidcBootstrapStackProps, RepoRole } from './lib/sta
 export { applyTags } from './lib/constructs/standard-tags';
 export { StaticSiteDashboard, StaticSiteDashboardProps } from './lib/constructs/static-site-dashboard';
 export { EcsExpressDashboard, EcsExpressDashboardProps } from './lib/constructs/ecs-express-dashboard';
+export {
+  EcsExpressObservability,
+  EcsExpressObservabilityProps,
+  ObservabilityProps,
+  ObservabilityTier,
+  ResolvedObservability,
+  resolveObservability,
+} from './lib/constructs/ecs-express-observability';

--- a/lib/constructs/ecs-express-observability.ts
+++ b/lib/constructs/ecs-express-observability.ts
@@ -1,0 +1,225 @@
+import { Duration } from 'aws-cdk-lib';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as cw from 'aws-cdk-lib/aws-cloudwatch';
+import * as cwactions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
+import {
+  AwsCustomResource,
+  AwsCustomResourcePolicy,
+  PhysicalResourceId,
+} from 'aws-cdk-lib/custom-resources';
+import { Construct } from 'constructs';
+import { EcsExpressDashboard } from './ecs-express-dashboard';
+
+export type ObservabilityTier = 'dev' | 'prod';
+
+/**
+ * Opt-in observability for an ECS Express app behind CloudFront. Absent on the
+ * edge stack = nothing is created (dashboards/alarms/logs are all opt-in).
+ *
+ * `tier` sets defaults; any field can be overridden:
+ *   dev  — dashboard, 1-week log retention. Cheap and quiet.
+ *   prod — dashboard, 90-day retention, CloudFront access logs, alarms -> SNS,
+ *          and X-Ray (the X-Ray flag is consumed by the app/bootstrap side; the
+ *          edge stack only records it — ECS Express can't run a tracing sidecar,
+ *          so tracing is daemonless in-app).
+ */
+export interface ObservabilityProps {
+  tier: ObservabilityTier;
+  /** CloudWatch dashboard. Default: true. */
+  dashboard?: boolean;
+  /** CloudWatch alarms (ALB 5xx/p99/unhealthy + ECS CPU/mem) -> SNS. Default: prod. */
+  alarms?: boolean;
+  /** CloudFront standard access logs (CDK auto-provisions the log bucket). Default: prod. */
+  accessLogs?: boolean;
+  /** Distributed tracing (X-Ray). Consumed by the app + bootstrap task role, not
+   *  the edge stack. Default: prod. */
+  xray?: boolean;
+  /** Retention applied to the ECS Express log group (see ecsLogGroupName).
+   *  Default: dev=1 week, prod=3 months. */
+  logRetention?: logs.RetentionDays;
+  /** Email subscribed to the alarm SNS topic (optional). */
+  alarmEmail?: string;
+  /** ECS Express log group name to apply retention to (Express owns the group,
+   *  so retention is set via a small custom resource). */
+  ecsLogGroupName?: string;
+}
+
+export interface ResolvedObservability {
+  tier: ObservabilityTier;
+  dashboard: boolean;
+  alarms: boolean;
+  accessLogs: boolean;
+  xray: boolean;
+  logRetention: logs.RetentionDays;
+  alarmEmail?: string;
+  ecsLogGroupName?: string;
+}
+
+/** Apply tier defaults, letting explicit fields win. */
+export function resolveObservability(o: ObservabilityProps): ResolvedObservability {
+  const prod = o.tier === 'prod';
+  return {
+    tier: o.tier,
+    dashboard: o.dashboard ?? true,
+    alarms: o.alarms ?? prod,
+    accessLogs: o.accessLogs ?? prod,
+    xray: o.xray ?? prod,
+    logRetention:
+      o.logRetention ?? (prod ? logs.RetentionDays.THREE_MONTHS : logs.RetentionDays.ONE_WEEK),
+    alarmEmail: o.alarmEmail,
+    ecsLogGroupName: o.ecsLogGroupName,
+  };
+}
+
+export interface EcsExpressObservabilityProps {
+  config: ResolvedObservability;
+  serviceName: string;
+  distribution: cloudfront.IDistribution;
+  dashboardName?: string;
+  /** ALB dimension `app/<name>/<id>` — enables ALB widgets + alarms. */
+  loadBalancerFullName?: string;
+  /** Target group dimension `targetgroup/<name>/<id>` — enables host-health. */
+  targetGroupFullName?: string;
+  /** ECS cluster name (default `default`) — enables compute widgets + alarms. */
+  ecsClusterName?: string;
+  /** ECS service name — enables compute widgets + alarms. */
+  ecsServiceName?: string;
+}
+
+/**
+ * Builds the dashboard + alarms + log retention for one ECS Express app.
+ * CloudFront access logging is configured on the Distribution itself (in the
+ * edge stack, since it must be set at creation), driven by the same config.
+ */
+export class EcsExpressObservability extends Construct {
+  public readonly dashboard?: EcsExpressDashboard;
+  public readonly alarmTopic?: sns.Topic;
+  public readonly alarms: cw.Alarm[] = [];
+
+  constructor(scope: Construct, id: string, props: EcsExpressObservabilityProps) {
+    super(scope, id);
+    const { config } = props;
+
+    if (config.dashboard) {
+      this.dashboard = new EcsExpressDashboard(this, 'Dashboard', {
+        distribution: props.distribution,
+        serviceName: props.serviceName,
+        dashboardName: props.dashboardName,
+        loadBalancerFullName: props.loadBalancerFullName,
+        targetGroupFullName: props.targetGroupFullName,
+        ecsClusterName: props.ecsClusterName,
+        ecsServiceName: props.ecsServiceName,
+      });
+    }
+
+    // Retention on the ECS Express-owned log group (foreign resource).
+    if (config.ecsLogGroupName) {
+      new AwsCustomResource(this, 'LogRetention', {
+        onUpdate: {
+          service: 'CloudWatchLogs',
+          action: 'putRetentionPolicy',
+          parameters: {
+            logGroupName: config.ecsLogGroupName,
+            retentionInDays: config.logRetention,
+          },
+          physicalResourceId: PhysicalResourceId.of(`retention-${config.ecsLogGroupName}`),
+        },
+        policy: AwsCustomResourcePolicy.fromSdkCalls({
+          resources: AwsCustomResourcePolicy.ANY_RESOURCE,
+        }),
+        installLatestAwsSdk: false,
+      });
+    }
+
+    if (config.alarms) {
+      this.alarmTopic = new sns.Topic(this, 'AlarmTopic', {
+        displayName: `${props.serviceName} alarms`,
+      });
+      if (config.alarmEmail) {
+        this.alarmTopic.addSubscription(new subs.EmailSubscription(config.alarmEmail));
+      }
+      const action = new cwactions.SnsAction(this.alarmTopic);
+
+      if (props.loadBalancerFullName) {
+        const lbDims = { LoadBalancer: props.loadBalancerFullName };
+        const albMetric = (metricName: string, statistic: string): cw.Metric =>
+          new cw.Metric({
+            namespace: 'AWS/ApplicationELB',
+            metricName,
+            dimensionsMap: lbDims,
+            statistic,
+            period: Duration.minutes(5),
+          });
+
+        this.alarms.push(
+          new cw.Alarm(this, 'Alb5xx', {
+            alarmDescription: `${props.serviceName}: ALB target 5xx`,
+            metric: albMetric('HTTPCode_Target_5XX_Count', 'Sum'),
+            threshold: 10,
+            evaluationPeriods: 1,
+            comparisonOperator: cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
+            treatMissingData: cw.TreatMissingData.NOT_BREACHING,
+          }),
+          new cw.Alarm(this, 'AlbLatencyP99', {
+            alarmDescription: `${props.serviceName}: ALB p99 target response time > 3s`,
+            metric: albMetric('TargetResponseTime', 'p99'),
+            threshold: 3,
+            evaluationPeriods: 3,
+            comparisonOperator: cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
+            treatMissingData: cw.TreatMissingData.NOT_BREACHING,
+          }),
+        );
+
+        if (props.targetGroupFullName) {
+          this.alarms.push(
+            new cw.Alarm(this, 'AlbUnhealthyHosts', {
+              alarmDescription: `${props.serviceName}: unhealthy targets`,
+              metric: new cw.Metric({
+                namespace: 'AWS/ApplicationELB',
+                metricName: 'UnHealthyHostCount',
+                dimensionsMap: {
+                  LoadBalancer: props.loadBalancerFullName,
+                  TargetGroup: props.targetGroupFullName,
+                },
+                statistic: 'Maximum',
+                period: Duration.minutes(1),
+              }),
+              threshold: 1,
+              evaluationPeriods: 3,
+              comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+              treatMissingData: cw.TreatMissingData.NOT_BREACHING,
+            }),
+          );
+        }
+      }
+
+      if (props.ecsClusterName && props.ecsServiceName) {
+        const ecsDims = { ClusterName: props.ecsClusterName, ServiceName: props.ecsServiceName };
+        const ecsAlarm = (id2: string, metricName: string, label: string): cw.Alarm =>
+          new cw.Alarm(this, id2, {
+            alarmDescription: `${props.serviceName}: ${label} > 85%`,
+            metric: new cw.Metric({
+              namespace: 'AWS/ECS',
+              metricName,
+              dimensionsMap: ecsDims,
+              statistic: 'Average',
+              period: Duration.minutes(5),
+            }),
+            threshold: 85,
+            evaluationPeriods: 3,
+            comparisonOperator: cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
+            treatMissingData: cw.TreatMissingData.NOT_BREACHING,
+          });
+        this.alarms.push(
+          ecsAlarm('EcsCpuHigh', 'CPUUtilization', 'CPU'),
+          ecsAlarm('EcsMemHigh', 'MemoryUtilization', 'memory'),
+        );
+      }
+
+      for (const alarm of this.alarms) alarm.addAlarmAction(action);
+    }
+  }
+}

--- a/lib/stacks/ecs-express-edge-stack.ts
+++ b/lib/stacks/ecs-express-edge-stack.ts
@@ -5,7 +5,11 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
 import { Construct } from 'constructs';
-import { EcsExpressDashboard } from '../constructs/ecs-express-dashboard';
+import {
+  EcsExpressObservability,
+  ObservabilityProps,
+  resolveObservability,
+} from '../constructs/ecs-express-observability';
 
 export interface EcsExpressEdgeStackProps extends cdk.StackProps {
   /**
@@ -38,23 +42,24 @@ export interface EcsExpressEdgeStackProps extends cdk.StackProps {
    *  HTTPS_ONLY only if you've attached a cert to the ALB's 443 listener. */
   originProtocolPolicy?: cloudfront.OriginProtocolPolicy;
 
-  // --- Observability -------------------------------------------------------
-  /** Friendly service name for the dashboard title/name. Defaults to
+  // --- Observability (opt-in) ----------------------------------------------
+  /** Friendly service name for dashboard/alarm naming. Defaults to
    *  `domainName`, else the ALB DNS name. */
   serviceName?: string;
-  /** Create a CloudWatch dashboard (CloudFront + ALB + ECS) for this app.
-   *  Defaults to true. */
-  createDashboard?: boolean;
+  /** Opt-in observability (dashboard, alarms, access logs, log retention,
+   *  X-Ray flag) with dev/prod tiers. OMIT to create nothing — the dashboard is
+   *  no longer on by default. */
+  observability?: ObservabilityProps;
   /** Override the dashboard name. Defaults to `${serviceName}-ecs-express`. */
   dashboardName?: string;
   /** ALB CloudWatch dimension `app/<lb-name>/<lb-id>` (tail of the ALB ARN).
-   *  Supply from the deploy workflow to add ALB widgets. */
+   *  Enables ALB widgets + alarms. */
   loadBalancerFullName?: string;
-  /** Target group dimension `targetgroup/<name>/<id>` for host-health widgets. */
+  /** Target group dimension `targetgroup/<name>/<id>` for host-health. */
   targetGroupFullName?: string;
-  /** ECS cluster name (from the service ARN) to add compute widgets. */
+  /** ECS cluster name (default `default`) for compute widgets + alarms. */
   ecsClusterName?: string;
-  /** ECS service name (from the service ARN) to add compute widgets. */
+  /** ECS service name for compute widgets + alarms. */
   ecsServiceName?: string;
 }
 
@@ -88,8 +93,8 @@ export class EcsExpressEdgeStack extends cdk.Stack {
   public readonly certificate?: acm.Certificate;
   /** Only set when a custom domain is configured. */
   public readonly hostedZone?: route53.IHostedZone;
-  /** Only set when createDashboard is not false. */
-  public readonly dashboard?: EcsExpressDashboard;
+  /** Only set when observability is enabled. */
+  public readonly observability?: EcsExpressObservability;
 
   constructor(scope: Construct, id: string, props: EcsExpressEdgeStackProps) {
     super(scope, id, props);
@@ -113,6 +118,8 @@ export class EcsExpressEdgeStack extends cdk.Stack {
         validation: acm.CertificateValidation.fromDns(this.hostedZone),
       });
     }
+
+    const obs = props.observability ? resolveObservability(props.observability) : undefined;
 
     const origin = new origins.HttpOrigin(props.albDnsName, {
       protocolPolicy: props.originProtocolPolicy ?? cloudfront.OriginProtocolPolicy.HTTP_ONLY,
@@ -151,6 +158,10 @@ export class EcsExpressEdgeStack extends cdk.Stack {
       priceClass: props.priceClass ?? cloudfront.PriceClass.PRICE_CLASS_100,
       httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
       minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
+      // CloudFront standard access logs — CDK provisions the log bucket. Since
+      // CloudFront fronts all traffic, these are the meaningful access logs
+      // (ALB-level logs would only add origin-fetch detail).
+      enableLogging: obs?.accessLogs ?? false,
       comment: `ECS Express edge for ${props.domainName ?? props.albDnsName}`,
     });
 
@@ -171,10 +182,11 @@ export class EcsExpressEdgeStack extends cdk.Stack {
     }
 
     const serviceName = props.serviceName ?? props.domainName ?? props.albDnsName;
-    if (props.createDashboard !== false) {
-      this.dashboard = new EcsExpressDashboard(this, 'Dashboard', {
-        distribution: this.distribution,
+    if (obs) {
+      this.observability = new EcsExpressObservability(this, 'Observability', {
+        config: obs,
         serviceName,
+        distribution: this.distribution,
         dashboardName: props.dashboardName,
         loadBalancerFullName: props.loadBalancerFullName,
         targetGroupFullName: props.targetGroupFullName,

--- a/test/ecs-express-edge-stack.test.ts
+++ b/test/ecs-express-edge-stack.test.ts
@@ -133,14 +133,56 @@ describe('EcsExpressEdgeStack', () => {
     expect(keys.some((k) => k.includes('SiteUrl'))).toBe(true);
   });
 
-  test('creates a CloudWatch dashboard by default', () => {
+  test('observability is opt-in: no dashboard/alarms by default', () => {
     const template = Template.fromStack(makeStack());
-    template.resourceCountIs('AWS::CloudWatch::Dashboard', 1);
+    template.resourceCountIs('AWS::CloudWatch::Dashboard', 0);
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 0);
   });
 
-  test('omits the dashboard when createDashboard is false', () => {
-    const template = Template.fromStack(makeStack({ createDashboard: false }));
-    template.resourceCountIs('AWS::CloudWatch::Dashboard', 0);
+  test('dev tier: dashboard, no alarms, no access logs', () => {
+    const template = Template.fromStack(makeStack({ observability: { tier: 'dev' } }));
+    template.resourceCountIs('AWS::CloudWatch::Dashboard', 1);
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({ Logging: Match.absent() }),
+    });
+  });
+
+  test('prod tier: dashboard + alarms + SNS + CloudFront access logs', () => {
+    const template = Template.fromStack(
+      makeStack({
+        observability: { tier: 'prod', alarmEmail: 'ops@kota.dog' },
+        loadBalancerFullName: 'app/homepage-alb/abc123',
+        targetGroupFullName: 'targetgroup/homepage-tg/def456',
+        ecsClusterName: 'default',
+        ecsServiceName: 'homepage',
+      }),
+    );
+    template.resourceCountIs('AWS::CloudWatch::Dashboard', 1);
+    template.resourceCountIs('AWS::SNS::Topic', 1);
+    // ALB 5xx, ALB p99, unhealthy hosts, ECS CPU, ECS mem = 5
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 5);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({ Logging: Match.anyValue() }),
+    });
+  });
+
+  test('prod tier with no ALB/ECS identifiers: no alarms wired', () => {
+    const template = Template.fromStack(makeStack({ observability: { tier: 'prod' } }));
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+  });
+
+  test('explicit overrides win over tier defaults (prod, alarms off)', () => {
+    const template = Template.fromStack(
+      makeStack({
+        observability: { tier: 'prod', alarms: false, accessLogs: false },
+        loadBalancerFullName: 'app/homepage-alb/abc123',
+      }),
+    );
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({ Logging: Match.absent() }),
+    });
   });
 });
 


### PR DESCRIPTION
Adds `observability?: { tier: 'dev'|'prod', ... }` to the L3. Opt-in (dashboard no longer default-on). prod = dashboard + alarms→SNS + CloudFront access logs + 90d retention + X-Ray flag; dev = dashboard + 1wk retention. 43 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)