### PR TITLE
feat(ci): job timeouts (ECS deploy 15m, build/edge 20m, mirror 10m)

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -56,6 +56,7 @@ jobs:
   build:
     name: Build & Push
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       digest: ${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -79,6 +79,7 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'deploy:dev')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       env: ${{ steps.c.outputs.env }}
       service: ${{ steps.c.outputs.service }}
@@ -119,6 +120,7 @@ jobs:
   changes:
     needs: [config]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       infra: ${{ steps.f.outputs.infra }}
     steps:
@@ -143,6 +145,7 @@ jobs:
   mirror:
     needs: [config, image]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       id-token: write
       contents: read
@@ -183,6 +186,7 @@ jobs:
       always() && needs.service.result == 'success' &&
       (github.event_name != 'push' || needs.changes.outputs.infra == 'true')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ecs-express-deploy.yml
+++ b/.github/workflows/ecs-express-deploy.yml
@@ -131,6 +131,9 @@ jobs:
   deploy:
     name: Deploy to ECS Express
     runs-on: ubuntu-latest
+    # Fail fast if ECS never reaches steady state (e.g. tasks failing health
+    # checks) instead of hanging on the action's stability wait.
+    timeout-minutes: 15
     outputs:
       service-arn: ${{ steps.deploy.outputs.service-arn }}
       endpoint: ${{ steps.deploy.outputs.endpoint }}


### PR DESCRIPTION
Adds timeout-minutes to the deploy-path jobs so a hung step (e.g. ECS never reaching steady state) fails fast instead of running for hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)