### PR TITLE
perf: zero canary bake + skip edge unless infra changed

### DIFF
--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: string
         default: ''
+      prod-bake-minutes:
+        description: 'Prod canary bake time (mins). 0 = promote as soon as healthy (default). Raise only for high-traffic services where alarm-based auto-rollback during the soak is worthwhile. Dev is always 0.'
+        required: false
+        type: string
+        default: '0'
     secrets:
       role-arn:
         required: true
@@ -88,6 +93,7 @@ jobs:
       obs_tier: ${{ steps.c.outputs.obs_tier }}
       stack: ${{ steps.c.outputs.stack }}
       cert_arn: ${{ steps.c.outputs.cert_arn }}
+      bake: ${{ steps.c.outputs.bake }}
     steps:
       - id: c
         env:
@@ -104,16 +110,21 @@ jobs:
             *)            ENV="${{ inputs.environment || 'dev' }}" ;;
           esac
           if [ "$ENV" = "prod" ]; then
+            # bake = prod-bake-minutes (default 0). Raise it only for a
+            # high-traffic service where alarm-based auto-rollback during the
+            # post-shift soak is meaningful (a low-traffic site's 4xx/5xx alarm
+            # rarely gets enough datapoints to fire anyway).
             {
               echo "env=prod"; echo "service=${APP}"; echo "min_tasks=1"
               echo "domain=${PROD_DOMAIN}"; echo "obs_tier=prod"; echo "stack=${PREFIX}Prod"
-              echo "cert_arn=${PROD_CERT}"
+              echo "cert_arn=${PROD_CERT}"; echo "bake=${{ inputs.prod-bake-minutes }}"
             } >> "$GITHUB_OUTPUT"
           else
+            # dev: zero canary bake -> promote as soon as healthy (~3-4 min deploys)
             {
               echo "env=dev"; echo "service=${APP}-dev"; echo "min_tasks=0"
               echo "domain=${DEV_DOMAIN}"; echo "obs_tier=dev"; echo "stack=${PREFIX}Dev"
-              echo "cert_arn=${DEV_CERT}"
+              echo "cert_arn=${DEV_CERT}"; echo "bake=0"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -175,6 +186,7 @@ jobs:
       container-port: ${{ inputs.container-port }}
       health-check-path: ${{ inputs.health-check-path }}
       min-task-count: ${{ fromJSON(needs.config.outputs.min_tasks) }}
+      bake-time-minutes: ${{ needs.config.outputs.bake }}
     secrets:
       role-arn: ${{ secrets.role-arn }}
       execution-role-arn: ${{ secrets.execution-role-arn }}
@@ -182,9 +194,12 @@ jobs:
 
   edge:
     needs: [config, service, changes]
+    # Only run the slow CloudFront edge when infra/ changed, or on a manual
+    # dispatch (first-time setup). Routine code pushes (prod) and PR updates
+    # (dev) skip it entirely -> much faster deploys.
     if: >-
       always() && needs.service.result == 'success' &&
-      (github.event_name != 'push' || needs.changes.outputs.infra == 'true')
+      (github.event_name == 'workflow_dispatch' || needs.changes.outputs.infra == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/ecs-express-deploy.yml
+++ b/.github/workflows/ecs-express-deploy.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: ''
+      bake-time-minutes:
+        description: 'Canary bake time (mins). 0 = promote as soon as healthy (fast, for dev). Empty = leave service default. Applied before deploy if the service already exists.'
+        required: false
+        type: string
+        default: ''
       container-port:
         description: 'Container port that receives traffic'
         required: false
@@ -147,6 +152,30 @@ jobs:
         with:
           role-to-assume: ${{ secrets.role-arn }}
           aws-region: ${{ inputs.aws-region }}
+
+      # ECS Express forces a CANARY strategy with a 3+3 min bake by default.
+      # The strategy can't change, but the bake CAN (0-1440). Setting it before
+      # the deploy makes the canary promote as soon as the task is healthy.
+      # (Only possible on an existing service; first-ever create uses defaults.)
+      - name: Set canary bake time
+        if: inputs.bake-time-minutes != ''
+        shell: bash
+        env:
+          SVC: ${{ inputs.service-name }}
+          CLUSTER: ${{ inputs.cluster || 'default' }}
+          BAKE: ${{ inputs.bake-time-minutes }}
+        run: |
+          CFG=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SVC" \
+            --query "services[?status=='ACTIVE']|[0].deploymentConfiguration" --output json 2>/dev/null || true)
+          if [ -n "$CFG" ] && [ "$CFG" != "null" ]; then
+            NEW=$(echo "$CFG" | jq --argjson b "$BAKE" \
+              '.bakeTimeInMinutes=$b | (.canaryConfiguration.canaryBakeTimeInMinutes)=$b')
+            aws ecs update-service --cluster "$CLUSTER" --service "$SVC" \
+              --deployment-configuration "$NEW" >/dev/null
+            echo "Set canary bake time to ${BAKE}m for $SVC"
+          else
+            echo "::notice::$SVC not found yet (first deploy) — bake stays at Express default"
+          fi
 
       - name: Deploy to ECS Express Mode
         id: deploy


### PR DESCRIPTION
Cuts ECS Express deploys from ~10 min to ~3-4 min by zeroing the canary bake time (strategy stays CANARY; bake 0-1440 is allowed per AWS docs). Edge job now only runs on infra changes / dispatch. Validated empirically: bake=0 deploy completed in 230s vs ~600s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)