### PR TITLE
fix(ci): GHCR auth in mirror for private images

### DIFF
--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -170,10 +170,15 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: read
     outputs:
       ecr-image: ${{ steps.mirror.outputs.ecr-image }}
     steps:
       - uses: actions/checkout@v4
+      # Auth to GHCR so crane can pull PRIVATE source images (public images
+      # work without this). Writes ~/.docker/config.json, which crane reads.
+      - name: Log in to GHCR
+        run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.role-arn }}


### PR DESCRIPTION
crane copy failed (401) on the private ad-homepage GHCR package. Add packages:read + docker login ghcr.io before the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)