### PR TITLE
fix(edge): forward query string to Next.js image optimizer

### DIFF
--- a/lib/stacks/ecs-express-edge-stack.ts
+++ b/lib/stacks/ecs-express-edge-stack.ts
@@ -141,11 +141,37 @@ export class EcsExpressEdgeStack extends cdk.Stack {
       compress: true,
     };
 
+    // The Next.js image optimizer (`/_next/image`) keys responses on the
+    // `?url`, `w` and `q` query string and the `Accept` header (avif/webp
+    // negotiation). CACHING_OPTIMIZED drops the query string, so the optimizer
+    // receives a bare `/_next/image` and 400s with "url parameter is required".
+    // Include those in the cache key (so each size caches separately) and
+    // forward them to the origin.
+    const imageCachePolicy = new cloudfront.CachePolicy(this, 'NextImageCachePolicy', {
+      comment: 'Next.js /_next/image: query string + Accept in cache key',
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+      headerBehavior: cloudfront.CacheHeaderBehavior.allowList('Accept'),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+      enableAcceptEncodingGzip: true,
+      enableAcceptEncodingBrotli: true,
+      minTtl: cdk.Duration.seconds(0),
+      defaultTtl: cdk.Duration.days(1),
+      maxTtl: cdk.Duration.days(365),
+    });
+
+    const imageBehavior: cloudfront.BehaviorOptions = {
+      origin,
+      viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+      cachePolicy: imageCachePolicy,
+      compress: true,
+    };
+
     this.distribution = new cloudfront.Distribution(this, 'EdgeDistribution', {
       defaultBehavior: ssrBehavior,
       additionalBehaviors: {
         '/_next/static/*': staticBehavior,
-        '/_next/image*': staticBehavior,
+        '/_next/image*': imageBehavior,
       },
       domainNames: aliases,
       certificate: this.certificate,

--- a/test/ecs-express-edge-stack.test.ts
+++ b/test/ecs-express-edge-stack.test.ts
@@ -56,6 +56,34 @@ describe('EcsExpressEdgeStack (Cloudflare DNS, no Route53)', () => {
     expect(patterns).toContain('/_next/image*');
   });
 
+  test('/_next/image* forwards the query string (a custom cache policy keyed on it)', () => {
+    const stack = makeStack();
+    const template = Template.fromStack(stack);
+
+    // A custom cache policy that includes the full query string in the key.
+    template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+      CachePolicyConfig: Match.objectLike({
+        ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
+          QueryStringsConfig: Match.objectLike({ QueryStringBehavior: 'all' }),
+        }),
+      }),
+    });
+
+    // The /_next/image* behavior must NOT use the managed CACHING_OPTIMIZED
+    // policy (which strips the query string and 400s the optimizer).
+    const dist = Object.values(template.findResources('AWS::CloudFront::Distribution'))[0] as {
+      Properties: {
+        DistributionConfig: { CacheBehaviors?: Array<{ PathPattern: string; CachePolicyId: unknown }> };
+      };
+    };
+    const CACHING_OPTIMIZED = '658327ea-f89d-4fab-a63d-7e88639e58f6';
+    const imageBehavior = (dist.Properties.DistributionConfig.CacheBehaviors ?? []).find(
+      (b) => b.PathPattern === '/_next/image*',
+    );
+    expect(imageBehavior).toBeDefined();
+    expect(imageBehavior?.CachePolicyId).not.toBe(CACHING_OPTIMIZED);
+  });
+
   test('allows all HTTP methods on the default behavior (SSR needs POST)', () => {
     const template = Template.fromStack(makeStack());
     template.hasResourceProperties('AWS::CloudFront::Distribution', {


### PR DESCRIPTION
## Problem
`EcsExpressEdgeStack` routed both `/_next/static/*` **and** `/_next/image*` through the same `staticBehavior`, which uses the managed **`CACHING_OPTIMIZED`** cache policy (no query string, no origin-request policy). CloudFront therefore stripped the `?url=&w=&q=` query string before reaching the origin, so the Next.js image optimizer received a bare `/_next/image` and returned **`400 "url" parameter is required`** — breaking every `next/image` (optimized) image behind CloudFront. Static `/_next/static/*` and `public/` assets were unaffected (no query string).

Observed in production on `kota.dog` (HomepageEdgeProd); `dev.kota.dog` had the same bug.

## Fix
Give `/_next/image*` its own behavior backed by a dedicated cache policy that includes the **query string (`url`, `w`, `q`)** and the **`Accept`** header (avif/webp negotiation) in the cache key — so they're forwarded to the origin and each size/format caches separately at the edge.

- `/_next/static/*` keeps `CACHING_OPTIMIZED` (content-hashed, no query string needed).
- Added a regression test asserting `/_next/image*` does **not** use `CACHING_OPTIMIZED` and that a custom cache policy with `QueryStringBehavior: all` exists.

## Verification
- `npm run build` ✓ · `npm test` ✓ (41 passing)
- Validated the equivalent fix live on the HomepageEdgeProd distribution: `/_next/image` now returns `200 image/webp` and caches per-size.

## Follow-up
Consumers pin this toolkit by tag (e.g. Homepage uses `#v2.4.0`); once released, bump the consumer to pick up the fix and `cdk deploy` the edge stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
