### PR TITLE
feat: www alias + 301 redirect to apex

### DIFF
--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -74,6 +74,11 @@ on:
         required: false
         type: string
         default: '0'
+      prod-additional-aliases:
+        description: 'Extra prod domains served by the same distribution (comma-separated, e.g. www.kota.dog). They are 301-redirected to the primary domain. Require coverage by prod-cert-arn (SAN). Prod only.'
+        required: false
+        type: string
+        default: ''
     secrets:
       role-arn:
         required: true
@@ -104,6 +109,7 @@ jobs:
       stack: ${{ steps.c.outputs.stack }}
       cert_arn: ${{ steps.c.outputs.cert_arn }}
       bake: ${{ steps.c.outputs.bake }}
+      aliases: ${{ steps.c.outputs.aliases }}
     steps:
       - id: c
         env:
@@ -113,6 +119,7 @@ jobs:
           DEV_DOMAIN: ${{ inputs.dev-domain }}
           PROD_CERT: ${{ inputs.prod-cert-arn }}
           DEV_CERT: ${{ inputs.dev-cert-arn }}
+          PROD_ALIASES: ${{ inputs.prod-additional-aliases }}
         run: |
           case "${{ github.event_name }}" in
             push)         ENV=prod ;;
@@ -128,13 +135,14 @@ jobs:
               echo "env=prod"; echo "service=${APP}"; echo "min_tasks=1"
               echo "domain=${PROD_DOMAIN}"; echo "obs_tier=prod"; echo "stack=${PREFIX}Prod"
               echo "cert_arn=${PROD_CERT}"; echo "bake=${{ inputs.prod-bake-minutes }}"
+              echo "aliases=${PROD_ALIASES}"
             } >> "$GITHUB_OUTPUT"
           else
             # dev: zero canary bake -> promote as soon as healthy (~3-4 min deploys)
             {
               echo "env=dev"; echo "service=${APP}-dev"; echo "min_tasks=0"
               echo "domain=${DEV_DOMAIN}"; echo "obs_tier=dev"; echo "stack=${PREFIX}Dev"
-              echo "cert_arn=${DEV_CERT}"; echo "bake=0"
+              echo "cert_arn=${DEV_CERT}"; echo "bake=0"; echo "aliases="
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -270,6 +278,7 @@ jobs:
             -c albDns='${{ needs.service.outputs.endpoint }}' \
             -c domainName=${{ needs.config.outputs.domain }} \
             -c certificateArn=${{ needs.config.outputs.cert_arn }} \
+            -c additionalAliases=${{ needs.config.outputs.aliases }} \
             -c observabilityTier=${{ needs.config.outputs.obs_tier }} \
             -c serviceName=${{ needs.config.outputs.service }} \
             -c dashboardName=${{ needs.config.outputs.stack }} \

--- a/lib/stacks/ecs-express-edge-stack.ts
+++ b/lib/stacks/ecs-express-edge-stack.ts
@@ -116,6 +116,26 @@ export class EcsExpressEdgeStack extends cdk.Stack {
 
     const obs = props.observability ? resolveObservability(props.observability) : undefined;
 
+    // Redirect any non-primary alias (e.g. www.kota.dog) to the primary domain
+    // with a 301 — at the edge, before the origin (so it works even though the
+    // origin request policy strips Host).
+    let fnAssoc: cloudfront.FunctionAssociation[] | undefined;
+    if (props.domainName && (props.additionalAliases?.length ?? 0) > 0) {
+      const apex = JSON.stringify(props.domainName);
+      const aliasRedirect = new cloudfront.Function(this, 'AliasRedirect', {
+        runtime: cloudfront.FunctionRuntime.JS_2_0,
+        comment: `Redirect non-${props.domainName} hosts to the apex (301)`,
+        code: cloudfront.FunctionCode.fromInline(
+          `function handler(event){var r=event.request;var h=r.headers.host;` +
+            `if(h&&h.value!==${apex}){var qs=r.querystring;var q='';` +
+            `for(var k in qs){q+=(q?'&':'?')+k+(qs[k].value?('='+qs[k].value):'');}` +
+            `return{statusCode:301,statusDescription:'Moved Permanently',` +
+            `headers:{location:{value:'https://'+${apex}+r.uri+q}}};}return r;}`,
+        ),
+      });
+      fnAssoc = [{ function: aliasRedirect, eventType: cloudfront.FunctionEventType.VIEWER_REQUEST }];
+    }
+
     const origin = new origins.HttpOrigin(props.albDnsName, {
       protocolPolicy: props.originProtocolPolicy ?? cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
       httpsPort: 443,
@@ -129,6 +149,7 @@ export class EcsExpressEdgeStack extends cdk.Stack {
       allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
       cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
       originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+      functionAssociations: fnAssoc,
       compress: true,
     };
 
@@ -138,6 +159,7 @@ export class EcsExpressEdgeStack extends cdk.Stack {
       viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
       allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
       cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+      functionAssociations: fnAssoc,
       compress: true,
     };
 

--- a/test/ecs-express-edge-stack.test.ts
+++ b/test/ecs-express-edge-stack.test.ts
@@ -88,6 +88,23 @@ describe('EcsExpressEdgeStack (Cloudflare DNS, no Route53)', () => {
     });
   });
 
+  test('additionalAliases: extra alias + a 301 redirect CloudFront function', () => {
+    const template = Template.fromStack(makeStack({ additionalAliases: ['www.kota.dog'] }));
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({ Aliases: Match.arrayWith(['kota.dog', 'www.kota.dog']) }),
+    });
+    template.resourceCountIs('AWS::CloudFront::Function', 1);
+    const fn = Object.values(template.findResources('AWS::CloudFront::Function'))[0] as {
+      Properties: { FunctionCode: string };
+    };
+    expect(fn.Properties.FunctionCode).toContain('301');
+  });
+
+  test('no redirect function without additionalAliases', () => {
+    const template = Template.fromStack(makeStack());
+    template.resourceCountIs('AWS::CloudFront::Function', 0);
+  });
+
   test('default-domain mode: no cert, no aliases', () => {
     const app = new cdk.App();
     const template = Template.fromStack(


### PR DESCRIPTION
additionalAliases (e.g. www) served by the same distro + a CloudFront Function that 301s non-apex hosts to the apex. Reusable workflow gets prod-additional-aliases. 42 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)