### PR TITLE
fix(commitlint): fetch full history so merge-base resolves on multi-commit PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,9 +23,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base commit
-        run: git fetch --depth=$(( ${{ github.event.pull_request.commits }} + 1 )) origin ${{ github.event.pull_request.base.sha }}
+          # Full history so commitlint can compute the merge-base between base
+          # and head. A shallow clone breaks `commitlint --from <base> --to <head>`
+          # with "Cannot find merge-base ... (shallow clone)" on multi-commit PRs.
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

`commitlint.yml` checks out with the default **shallow** clone (`fetch-depth: 1`) and then fetches only a few base commits. commitlint v20 needs to compute the **merge-base** between the PR base and head; with that truncated history it fails:

```
Cannot find merge-base between '<base>' and '<head>'. This typically indicates
incomplete git history (e.g., a shallow clone). Consider fetching more history.
```

This fails **any multi-commit PR** regardless of whether the commit messages are valid (they lint fine locally). Hit on `KotaHusky/Homepage#55`.

## Fix

Check out **full history** (`fetch-depth: 0`) and drop the fragile partial "Fetch base commit" step. With complete history, `commitlint --from <base> --to <head>` resolves the merge-base normally.

## Impact

- Unblocks multi-commit PRs across all consumers of this reusable workflow.
- Slightly more git history fetched (negligible for these repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
