### PR TITLE
fix(ci): use full history in commitlint so merge-base resolves

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,9 +23,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base commit
-        run: git fetch --depth=$(( ${{ github.event.pull_request.commits }} + 1 )) origin ${{ github.event.pull_request.base.sha }}
+          # Full history so `commitlint --from base --to head` can resolve the
+          # merge-base. A shallow head checkout plus a separate shallow base
+          # fetch leaves the two histories disconnected, which fails even for a
+          # single-commit PR with "Cannot find merge-base between <base> <head>".
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem
The reusable `commitlint.yml` fails on PRs with:

```
Cannot find merge-base between <base.sha> and <head.sha>.
This typically indicates incomplete git history (e.g., a shallow clone).
```

Root cause: it checks out the PR **head** at `fetch-depth: 1`, then fetches the **base** SHA in a *separate* shallow `git fetch --depth=…`. The two histories stay disconnected, so `commitlint --from base --to head` can't compute a merge-base — it fails **even for a single-commit PR** whose head's parent *is* the base.

This is the "targeted fetch instead of fetch-depth 0" approach from the merged #21 — that optimization is the regression. Observed live: KotaHusky/kinky-connections-app PR #433 (1 commit) red on this exact error while `ci-gate` was green.

## Fix
Replace the shallow head checkout + manual base fetch with `fetch-depth: 0`. Full history makes the commit range resolve cleanly. One step removed, one line added.

## Why fetch-depth: 0 over targeted fetch
Targeted/shallow fetching two endpoints is fragile — squash merges, multi-commit PRs, and force-pushed bases all break merge-base resolution. `fetch-depth: 0` is the standard, robust pattern for commitlint/semantic-PR checks; the repos are small enough that the clone cost is negligible.

## Release / rollout
cicd-toolkit self-releases (`self-release.yml` + `semver-tag.yml`); merging this `fix:` cuts a new `v2.x` and moves the `v2` major tag. Consumers pinned to `@v2` (e.g. kinky-connections `ci.yml`) pick it up automatically on their next run.