### PR TITLE
fix(iam): KC deploy role ListStacks grant + codify direct resource ops

### DIFF
--- a/bin/bootstrap.ts
+++ b/bin/bootstrap.ts
@@ -79,6 +79,28 @@ new OidcBootstrapStack(app, 'OidcBootstrapStack', {
             'arn:aws:cloudformation:*:*:stack/cdk-*/*',
           ],
         }),
+        // Account-scoped CloudFormation actions that do NOT support resource-level
+        // permissions and must be granted on '*'. ListStacks is used by CDK's
+        // rollback-detection pre-check; without it the deploy logs AccessDenied.
+        new iam.PolicyStatement({
+          actions: ['cloudformation:ListStacks'],
+          resources: ['*'],
+        }),
+        // Cloud Control direct resource ops used by `cdk deploy --method=direct`.
+        // Previously added to the live role only as a CLI stopgap
+        // (inline policy GitHubDeployDirectResourceOps); codified here so a
+        // re-bootstrap does not silently drop it.
+        new iam.PolicyStatement({
+          sid: 'CdkDirectDeployResourceOps',
+          actions: [
+            'cloudformation:CreateResource',
+            'cloudformation:UpdateResource',
+            'cloudformation:DeleteResource',
+            'cloudformation:GetResource',
+            'cloudformation:ListResources',
+          ],
+          resources: ['arn:aws:cloudformation:*:*:resource/*'],
+        }),
         new iam.PolicyStatement({
           actions: ['s3:*'],
           resources: [


### PR DESCRIPTION
## Problem
`KinkyConnections-GitHubDeploy` grants `cloudformation:*` only on specific stack ARNs (`stack/KinkyConnections-*/*`, etc.). Two gaps:

1. **`cloudformation:ListStacks` is account-scoped** — it doesn't support resource-level permissions, so scoping it to `stack/*` effectively **denies** it. CDK's rollback-detection pre-check then logs `AccessDenied` on every deploy. Confirmed live (KotaHusky/kinky-connections-app #432 blocker #2; seen non-fatally in the #433 dev deploy logs).
2. **Cloud Control direct resource ops** (`Create/Update/Delete/Get/ListResources`) needed by `cdk deploy --method=direct` exist **only as a live CLI stopgap** (inline policy `GitHubDeployDirectResourceOps`) — not in code. A re-bootstrap would silently drop them.

## Fix
Two added statements in `bin/bootstrap.ts` for the KC role:
- `cloudformation:ListStacks` on `*`.
- `CdkDirectDeployResourceOps` — the five Cloud Control actions on `arn:aws:cloudformation:*:*:resource/*`, codifying the stopgap.

## Validation
`npm test` ✅ · `npm run build` ✅ · `npx cdk synth` ✅ — synthesized template contains `ListStacks`, the `CdkDirectDeployResourceOps` Sid, and `UpdateResource`.

## Rollout
Applying requires **deploying the OidcBootstrap stack** to update the role (IAM change — not auto-applied by merge). Non-urgent: the `ListStacks` denial is non-fatal (pre-check noise), and the resource-ops are already present on the live role; this PR makes them durable in code.

Resolves KotaHusky/kinky-connections-app#428.