### PR TITLE
feat(ci): optional GitHub Packages auth for build-verify + docker-ghcr

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: 'npm'
+    secrets:
+      node-auth-token:
+        description: 'Token for installing private GitHub Packages (npm) deps. Optional.'
+        required: false
 
 concurrency:
   group: verify-${{ github.workflow }}-${{ github.ref }}
@@ -57,6 +61,8 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.node-auth-token }}
 
       - name: Save node_modules cache
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -43,6 +43,10 @@ on:
       digest:
         description: 'Image digest'
         value: ${{ jobs.build.outputs.digest }}
+    secrets:
+      node-auth-token:
+        description: 'Token for installing private GitHub Packages (npm) deps during the build. Optional.'
+        required: false
 
 concurrency:
   group: docker-${{ github.workflow }}-${{ github.ref }}
@@ -107,5 +111,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
+          secrets: |
+            node_auth_token=${{ secrets.node-auth-token }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## What

Add an **optional** `node-auth-token` secret to the two reusable workflows that run `npm` installs, so consuming repos with **private `@scope` GitHub Packages dependencies** can authenticate.

- **`build-verify.yml`** — sets `NODE_AUTH_TOKEN` on the `npm ci` step (the consumer's `.npmrc` maps the scope + reads the token).
- **`docker-ghcr.yml`** — forwards it to `docker/build-push-action` as the `node_auth_token` BuildKit secret, so a Dockerfile can `--mount=type=secret,id=node_auth_token,env=NODE_AUTH_TOKEN` during `npm ci` (token never lands in a layer).

## Why

`AD-Homepage` now consumes `@kotahusky/ui` (private, published from `Homepage`). Its CI (`build-verify`), Docker build (`docker-ghcr`), and release all run `npm ci`, which currently 401s on the private scope. This is the shared plumbing for that.

## Backward compatibility

The secret is `required: false`. Callers that don't pass it are unaffected — `${{ secrets.node-auth-token }}` resolves to empty, and repos without private-scope deps never reference it. No behavior change for existing consumers.

## Consumer usage

```yaml
jobs:
  verify:
    uses: KotaHusky/cicd-toolkit/.github/workflows/build-verify.yml@main
    secrets:
      node-auth-token: ${{ secrets.PACKAGES_READ_TOKEN }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
