### PR TITLE
feat(ci): optional GitHub Packages auth for commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: '24'
+    secrets:
+      node-auth-token:
+        description: 'Token for installing private GitHub Packages (npm) deps. Optional.'
+        required: false
 
 concurrency:
   group: commitlint-${{ github.workflow }}-${{ github.ref }}
@@ -36,6 +40,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.node-auth-token }}
 
       - name: Run commitlint
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Mirror of #48 for commitlint.yml: it runs `npm ci` (to get the commitlint CLI), which 401s when a consumer has a private `@scope` dependency. Adds the optional `node-auth-token` secret → `NODE_AUTH_TOKEN` on install. Backward-compatible. Needed so AD-Homepage's commitlint job can install now that it depends on `@kotahusky/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)