### PR TITLE
feat(ecs-deploy): forward optional node-auth-token to the image build

### DIFF
--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -86,6 +86,9 @@ on:
         required: true
       infrastructure-role-arn:
         required: true
+      node-auth-token:
+        description: 'PAT (read:packages) for private npm deps during the image build. Optional; omit for public-dep apps.'
+        required: false
 
 permissions:
   contents: read
@@ -151,6 +154,8 @@ jobs:
     uses: KotaHusky/cicd-toolkit/.github/workflows/docker-ghcr.yml@main
     with:
       push: true
+    secrets:
+      node-auth-token: ${{ secrets.node-auth-token }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem
Apps that consume **private** GitHub Packages 401 during ECS deploy. The chain is:

```
<app>/deploy-aws.yml → ecs-express-app-deploy.yml → image job → docker-ghcr.yml
```

`docker-ghcr.yml` already reads a `node-auth-token` secret and mounts it into the Docker build, but this orchestrator never **declared** or **forwarded** one, so the token arrives empty (`##[warning] node_auth_token= is not a valid secret`) and `npm ci` fails on the private dep.

## Fix
- Declare `node-auth-token` as an **optional** `workflow_call` secret (`required: false`).
- Forward it to the `image` job's `docker-ghcr.yml` call.

## Compatibility
Fully backward-compatible — public-dep callers (e.g. homepage) simply don't pass it and are unaffected. Mirrors the pattern already merged in #48/#49 for the CI workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)