### PR TITLE
chore: bump GitHub Actions to latest versions (Node.js 24 compat)

### DIFF
--- a/.github/workflows/aca-provision.yml
+++ b/.github/workflows/aca-provision.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: azure/login@v2
         with:

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -43,17 +43,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.package-manager }}
 
       - name: Restore node_modules
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
@@ -78,21 +78,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.2.1
+        uses: rharkor/caching-for-turbo@v2.5.0
 
       - name: Build
         run: npx turbo run build
@@ -104,21 +104,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.2.1
+        uses: rharkor/caching-for-turbo@v2.5.0
 
       - name: Test
         run: npx turbo run test
@@ -130,21 +130,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.2.1
+        uses: rharkor/caching-for-turbo@v2.5.0
 
       - name: Lint
         run: npx turbo run lint

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -86,7 +86,7 @@ jobs:
     outputs:
       deployed: ${{ steps.deploy.outcome == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout-ref || github.ref }}
 

--- a/.github/workflows/cdk-synth.yml
+++ b/.github/workflows/cdk-synth.yml
@@ -28,7 +28,7 @@ jobs:
     name: CDK Synth
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: KotaHusky/cicd-toolkit/actions/turbo-setup@v2
         with:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           # Full history so commitlint can compute the merge-base between base
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -66,7 +66,7 @@ jobs:
       digest: ${{ steps.build-push.outputs.digest }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -171,7 +171,7 @@ jobs:
     outputs:
       ecr-image: ${{ steps.mirror.outputs.ecr-image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Auth to GHCR so crane can pull PRIVATE source images (public images
       # work without this). Writes ~/.docker/config.json, which crane reads.
       - name: Log in to GHCR
@@ -218,8 +218,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - uses: aws-actions/configure-aws-credentials@v4
@@ -250,7 +250,7 @@ jobs:
             echo "::warning::ECS Express gateway ALB not found; dashboard ALB widgets skipped"
           fi
       - name: Cache infra node_modules (rebuilds the cicd-toolkit git dep)
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: infra/node_modules
           key: infra-nm-${{ runner.os }}-${{ hashFiles('infra/package-lock.json') }}

--- a/.github/workflows/ecs-express-deploy.yml
+++ b/.github/workflows/ecs-express-deploy.yml
@@ -143,7 +143,7 @@ jobs:
       service-arn: ${{ steps.deploy.outputs.service-arn }}
       endpoint: ${{ steps.deploy.outputs.endpoint }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout-ref || github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       release-url: ${{ steps.create-release.outputs.release-url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-tags: true
 

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -40,7 +40,7 @@ jobs:
       bumped: ${{ steps.tag.outputs.new_version != '' }}
       changelog: ${{ steps.tag.outputs.changelog }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/static-s3-deploy.yml
+++ b/.github/workflows/static-s3-deploy.yml
@@ -97,11 +97,11 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout-ref || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.package-manager }}

--- a/actions/turbo-setup/action.yml
+++ b/actions/turbo-setup/action.yml
@@ -15,13 +15,13 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Restore node_modules cache
       id: cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: node_modules
         key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
@@ -33,13 +33,13 @@ runs:
 
     - name: Save node_modules cache
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: node_modules
         key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
     - name: Turbo remote cache
-      uses: rharkor/caching-for-turbo@v2.2.1
+      uses: rharkor/caching-for-turbo@v2.5.0
 
     - name: Pre-build workspace packages
       if: inputs.pre-build-filter != ''


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v6
- `actions/cache` (restore/save/full) v4 → v6
- `rharkor/caching-for-turbo` v2.2.1 → v2.5.0

Resolves the Node.js 20 deprecation annotations across all 11 workflow files and the `turbo-setup` composite action. The `dorny/paths-filter@v3` annotation is not from this repo — it's in a consumer workflow.

## Test plan

- [ ] Verify `build-verify` workflow runs clean (Install / Build / Test / Lint jobs)
- [ ] Verify `commitlint` workflow runs clean on a PR
- [ ] Verify `semver-tag` workflow runs clean on a push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)