### PR TITLE
feat(claude-review): add reusable Claude code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,120 @@
+name: Reusable Claude Code Review
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: >-
+          GitHub environment (in the calling repo) to source secrets from.
+          Requires the caller to pass `secrets: inherit`.
+        required: false
+        type: string
+        default: ''
+      model:
+        description: 'Claude model override (e.g. claude-sonnet-4-6). Empty uses the action default.'
+        required: false
+        type: string
+        default: ''
+      review-prompt:
+        description: 'Extra project-specific review instructions appended to the default prompt'
+        required: false
+        type: string
+        default: ''
+      max-turns:
+        description: 'Max agent turns per review (cost control)'
+        required: false
+        type: string
+        default: '25'
+      fail-on-missing-key:
+        description: >-
+          When no Anthropic credentials are available: fail the job with an
+          error annotation (true) or skip the review with a warning annotation (false).
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key (pay-per-token). Optional if CLAUDE_CODE_OAUTH_TOKEN is set.'
+        required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: 'Claude Pro/Max OAuth token from `claude setup-token`. Optional if ANTHROPIC_API_KEY is set.'
+        required: false
+
+concurrency:
+  group: claude-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+  actions: read
+
+jobs:
+  review:
+    name: Claude Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      # The `secrets` context is not allowed in job-level `if`, so gate in a step.
+      - name: Check for Anthropic credentials
+        id: gate
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          FAIL_ON_MISSING: ${{ inputs.fail-on-missing-key }}
+          ENV_NAME: ${{ inputs.environment }}
+        run: |
+          if [ -n "${ANTHROPIC_API_KEY}" ] || [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has-credentials=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has-credentials=false" >> "$GITHUB_OUTPUT"
+
+          MSG="No ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN secret reached the Claude review workflow."
+          if [ -n "${ENV_NAME}" ]; then
+            MSG="${MSG} The '${ENV_NAME}' environment was selected — check that the secret exists in that environment and that the caller passes 'secrets: inherit'."
+          else
+            MSG="${MSG} Set a repo secret (gh secret set ANTHROPIC_API_KEY) and pass it via 'secrets:', or use a GitHub environment via the 'environment' input plus 'secrets: inherit'."
+          fi
+
+          if [ "${FAIL_ON_MISSING}" = "true" ]; then
+            echo "::error title=Claude code review: missing credentials::${MSG}"
+            exit 1
+          fi
+          echo "::warning title=Claude code review skipped: missing credentials::${MSG}"
+
+      - name: Checkout code
+        if: steps.gate.outputs.has-credentials == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code review
+        if: steps.gate.outputs.has-credentials == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for:
+            - Correctness bugs and unhandled edge cases
+            - Security issues (injection, secrets handling, authz)
+            - Significant performance problems
+            - Clarity or maintainability issues worth fixing now
+
+            Be concise and high-signal; skip nitpicks and style preferences.
+            Use inline comments for line-specific findings, then post a short
+            summary (overall assessment plus any blocking items).
+
+            ${{ inputs.review-prompt }}
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,10 +25,10 @@ on:
         required: false
         type: string
         default: '25'
-      fail-on-missing-key:
+      strict:
         description: >-
-          When no Anthropic credentials are available: fail the job with an
-          error annotation (true) or skip the review with a warning annotation (false).
+          Fail the job when the review cannot run (missing credentials or a
+          review error). Default: emit a notice annotation and let the job pass.
         required: false
         type: boolean
         default: false
@@ -64,7 +64,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          FAIL_ON_MISSING: ${{ inputs.fail-on-missing-key }}
+          STRICT: ${{ inputs.strict }}
           ENV_NAME: ${{ inputs.environment }}
         run: |
           if [ -n "${ANTHROPIC_API_KEY}" ] || [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
@@ -80,11 +80,11 @@ jobs:
             MSG="${MSG} Set a repo secret (gh secret set ANTHROPIC_API_KEY) and pass it via 'secrets:', or use a GitHub environment via the 'environment' input plus 'secrets: inherit'."
           fi
 
-          if [ "${FAIL_ON_MISSING}" = "true" ]; then
+          if [ "${STRICT}" = "true" ]; then
             echo "::error title=Claude code review: missing credentials::${MSG}"
             exit 1
           fi
-          echo "::warning title=Claude code review skipped: missing credentials::${MSG}"
+          echo "::notice title=Claude code review skipped: missing credentials::${MSG}"
 
       - name: Checkout code
         if: steps.gate.outputs.has-credentials == 'true'
@@ -93,7 +93,9 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code review
+        id: review
         if: steps.gate.outputs.has-credentials == 'true'
+        continue-on-error: ${{ !inputs.strict }}
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -118,3 +120,8 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
             --max-turns ${{ inputs.max-turns }}
             ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
+
+      - name: Report incomplete review
+        if: steps.gate.outputs.has-credentials == 'true' && steps.review.outcome == 'failure'
+        run: |
+          echo "::notice title=Claude code review did not complete::The review step failed — see its logs above. The job still passes because strict mode is off; set 'strict: true' to fail the job instead."

--- a/README.md
+++ b/README.md
@@ -175,6 +175,53 @@ jobs:
 
 The workflow compares commits between the current and previous semver tags, sends the log to Claude, and creates a release titled `v1.2.0 — <AI-generated title>` with a summary and full changelog.
 
+### Claude Code Review
+
+**`claude-review.yml`** — Automated Claude review on pull requests via [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action). Posts inline comments for line-specific findings plus one sticky summary comment that updates on new pushes.
+
+Requires the [Claude GitHub App](https://github.com/apps/claude) to be installed on the consuming repo.
+
+```yaml
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+jobs:
+  review:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/claude-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+To source the key from a GitHub environment in the consuming repo instead of a repo secret, pass the environment name and inherit secrets (environment secrets only resolve with `secrets: inherit`):
+
+```yaml
+    with:
+      environment: claude
+    secrets: inherit
+```
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `environment` | string | `''` | GitHub environment (in the calling repo) to source secrets from; requires `secrets: inherit` |
+| `model` | string | `''` | Claude model override; empty uses the action default |
+| `review-prompt` | string | `''` | Extra project-specific review instructions |
+| `max-turns` | string | `25` | Max agent turns per review (cost control) |
+| `fail-on-missing-key` | boolean | `false` | Fail with an error annotation when credentials are missing, instead of warning and skipping |
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `ANTHROPIC_API_KEY` | one of | Anthropic API key (pay-per-token billing) |
+| `CLAUDE_CODE_OAUTH_TOKEN` | one of | Claude Pro/Max OAuth token from `claude setup-token` (uses subscription quota) |
+
+If neither secret is available at run time, the workflow emits a **warning annotation** and skips the review without failing the caller's CI; set `fail-on-missing-key: true` to fail the job with an **error annotation** instead.
+
 ## Setup
 
 ### Secrets
@@ -182,14 +229,14 @@ The workflow compares commits between the current and previous semver tags, send
 Consumer repos need to configure the following secrets depending on which workflows they use:
 
 ```bash
-# For AI-powered releases (release.yml)
+# For AI-powered releases (release.yml) and Claude code review (claude-review.yml)
 gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
 
 # For CDK deployments (cdk-deploy.yml)
 gh secret set AWS_DEPLOY_ROLE_ARN --repo <owner>/<repo>
 ```
 
-Generate your Anthropic API key at [console.anthropic.com](https://console.anthropic.com/) under API Keys.
+Generate your Anthropic API key at [console.anthropic.com](https://console.anthropic.com/) under API Keys. For `claude-review.yml`, also install the [Claude GitHub App](https://github.com/apps/claude) on the repo; Claude Pro/Max subscribers can set `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) instead of an API key to draw on subscription usage rather than per-token billing.
 
 ### OIDC Bootstrap (CDK Deploy)
 

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ To source the key from a GitHub environment in the consuming repo instead of a r
 | `model` | string | `''` | Claude model override; empty uses the action default |
 | `review-prompt` | string | `''` | Extra project-specific review instructions |
 | `max-turns` | string | `25` | Max agent turns per review (cost control) |
-| `fail-on-missing-key` | boolean | `false` | Fail with an error annotation when credentials are missing, instead of warning and skipping |
+| `strict` | boolean | `false` | Fail the job when the review can't run (missing credentials or a review error); default is a notice annotation and a passing job |
 
 | Secret | Required | Description |
 |--------|----------|-------------|
 | `ANTHROPIC_API_KEY` | one of | Anthropic API key (pay-per-token billing) |
 | `CLAUDE_CODE_OAUTH_TOKEN` | one of | Claude Pro/Max OAuth token from `claude setup-token` (uses subscription quota) |
 
-If neither secret is available at run time, the workflow emits a **warning annotation** and skips the review without failing the caller's CI; set `fail-on-missing-key: true` to fail the job with an **error annotation** instead.
+The review is advisory by default: if no credentials are available, or the review step itself errors, the run emits a **notice annotation** and the job still passes — the caller's CI is never blocked. Set `strict: true` to fail the job with an **error annotation** instead.
 
 ## Setup
 

--- a/examples/claude-review.yml
+++ b/examples/claude-review.yml
@@ -9,8 +9,9 @@
 #        pass `environment: <name>` with `secrets: inherit` (see below)
 #      - Claude Pro/Max:     gh secret set CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`)
 #
-# If no credentials are available, the run posts a warning annotation and skips
-# the review (set fail-on-missing-key: true to fail the job instead).
+# The review is advisory: if credentials are missing or the review errors, the
+# run posts a notice annotation and the job still passes. Set strict: true to
+# fail the job instead.
 
 name: Claude Review
 
@@ -32,7 +33,7 @@ jobs:
     # with:
     #   model: 'claude-sonnet-4-6'     # override the default model
     #   max-turns: '15'                # tighten the cost cap
-    #   fail-on-missing-key: true      # fail instead of warn+skip
+    #   strict: true                   # fail the job if the review can't run
     #   review-prompt: |               # project-specific focus areas
     #     Pay extra attention to the public API surface in src/api/.
 

--- a/examples/claude-review.yml
+++ b/examples/claude-review.yml
@@ -1,0 +1,50 @@
+# Example Claude code review pipeline using cicd-toolkit.
+# Copy this file to your repo at .github/workflows/claude-review.yml and adjust as needed.
+#
+# Prerequisites:
+#   1. Install the Claude GitHub App on the repo: https://github.com/apps/claude
+#   2. Provide Anthropic credentials (choose one):
+#      - Repo secret:        gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
+#      - Environment secret: put ANTHROPIC_API_KEY in a GitHub environment and
+#        pass `environment: <name>` with `secrets: inherit` (see below)
+#      - Claude Pro/Max:     gh secret set CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`)
+#
+# If no credentials are available, the run posts a warning annotation and skips
+# the review (set fail-on-missing-key: true to fail the job instead).
+
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+jobs:
+  review:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/claude-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    # with:
+    #   model: 'claude-sonnet-4-6'     # override the default model
+    #   max-turns: '15'                # tighten the cost cap
+    #   fail-on-missing-key: true      # fail instead of warn+skip
+    #   review-prompt: |               # project-specific focus areas
+    #     Pay extra attention to the public API surface in src/api/.
+
+  # --- Alternative: source the key from a GitHub environment ---
+  # review:
+  #   uses: KotaHusky/cicd-toolkit/.github/workflows/claude-review.yml@main
+  #   permissions:
+  #     contents: read
+  #     pull-requests: write
+  #     issues: read
+  #     id-token: write
+  #     actions: read
+  #   with:
+  #     environment: claude   # environment in YOUR repo holding ANTHROPIC_API_KEY
+  #   secrets: inherit        # required for environment secrets to resolve


### PR DESCRIPTION
## Summary
- New `workflow_call` workflow `.github/workflows/claude-review.yml` running [anthropics/claude-code-action@v1](https://github.com/anthropics/claude-code-action) for automated PR review (inline comments + one sticky summary comment, updated on new pushes)
- Credentials: explicit `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` secrets, or sourced from a GitHub environment in the consuming repo via the `environment` input + `secrets: inherit`
- **Advisory by default**: if credentials are missing or the review step errors, the run emits a notice annotation and the job passes — consumer CI is never blocked. `strict: true` turns both cases into an error annotation + job failure. (The gate is a step because the `secrets` context is not allowed in job-level `if`.)
- Cost controls: `max-turns` cap (default 25), `concurrency` cancels superseded reviews on new pushes, optional `model` override
- Docs: README section with caller example + inputs/secrets tables, `examples/claude-review.yml` copy-paste caller

## Prerequisites for consumers
- Install the [Claude GitHub App](https://github.com/apps/claude) on the repo
- Provide an Anthropic API key (pay-per-token) or a Claude Pro/Max OAuth token (`claude setup-token`, uses subscription quota)

## Test plan
- [x] `vitest run` — 42/42 pass
- [x] Both YAML files parse cleanly
- [ ] Point a consumer repo at `@feat/claude-code-review` and open a test PR (workflows can't run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)