### PR TITLE
feat: Claude Code plugin marketplace + Claude PR reviewer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "cicd-toolkit",
+  "owner": {
+    "name": "KotaHusky"
+  },
+  "plugins": [
+    {
+      "name": "cicd-toolkit",
+      "source": "./plugins/cicd-toolkit",
+      "description": "Skills for integrating KotaHusky/cicd-toolkit reusable workflows, composite actions, and CDK constructs into consumer repos."
+    }
+  ]
+}

--- a/.github/workflows/claude-review-self.yml
+++ b/.github/workflows/claude-review-self.yml
@@ -1,0 +1,32 @@
+name: Claude PR Review (self)
+
+# Dogfoods this repo's own reusable claude-review.yml on every PR.
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+jobs:
+  review:
+    # Skip bot-authored PRs (e.g. dependabot) — nothing useful to review,
+    # and secrets aren't exposed to bot-triggered runs anyway.
+    if: github.event.pull_request.user.type != 'Bot'
+    uses: ./.github/workflows/claude-review.yml
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      max-turns: '15'
+      review-prompt: |
+        This repo is a reusable-workflow library that consumers pin at @main,
+        so changes ship to all consumers on merge. Weight these heavily:
+        - correctness bugs in workflow YAML and embedded shell (set -euo pipefail
+          pitfalls, quoting, commands that legitimately exit non-zero)
+        - breaking changes to workflow/action inputs, outputs, or secrets
+        - drift between the change and the README docs, examples/ callers, or
+          the plugins/cicd-toolkit skills

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,35 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    # Skip bot-authored PRs (e.g. dependabot) — nothing useful to review
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          prompt: |
+            Review this PR. Focus on what matters for a reusable-workflow library
+            that consumers pin at @main (changes ship to all consumers on merge):
+            - correctness bugs in workflow YAML and embedded shell (set -euo pipefail
+              pitfalls, quoting, commands that legitimately exit non-zero)
+            - breaking changes to workflow/action inputs, outputs, or secrets
+            - drift between the change and the README docs or examples/ callers
+            - security issues (secret handling, injection via untrusted inputs)
+          claude_args: "--max-turns 8"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,35 +1,128 @@
-name: Claude PR Review
+name: Reusable Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_call:
+    inputs:
+      environment:
+        description: >-
+          GitHub environment (in the calling repo) to source secrets from.
+          Requires the caller to pass `secrets: inherit`.
+        required: false
+        type: string
+        default: ''
+      model:
+        description: 'Claude model override (e.g. claude-sonnet-4-6). Empty uses the action default.'
+        required: false
+        type: string
+        default: ''
+      review-prompt:
+        description: 'Extra project-specific review instructions appended to the default prompt'
+        required: false
+        type: string
+        default: ''
+      max-turns:
+        description: 'Max agent turns per review (cost control)'
+        required: false
+        type: string
+        default: '25'
+      strict:
+        description: >-
+          Fail the job when the review cannot run (missing credentials or a
+          review error). Default: emit a notice annotation and let the job pass.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key (pay-per-token). Optional if CLAUDE_CODE_OAUTH_TOKEN is set.'
+        required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: 'Claude Pro/Max OAuth token from `claude setup-token`. Optional if ANTHROPIC_API_KEY is set.'
+        required: false
+
+concurrency:
+  group: claude-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+  actions: read
 
 jobs:
   review:
-    # Skip bot-authored PRs (e.g. dependabot) — nothing useful to review
-    if: github.event.pull_request.user.type != 'Bot'
+    name: Claude Review
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
+    timeout-minutes: 30
+    environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      # The `secrets` context is not allowed in job-level `if`, so gate in a step.
+      - name: Check for Anthropic credentials
+        id: gate
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          STRICT: ${{ inputs.strict }}
+          ENV_NAME: ${{ inputs.environment }}
+        run: |
+          if [ -n "${ANTHROPIC_API_KEY}" ] || [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has-credentials=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has-credentials=false" >> "$GITHUB_OUTPUT"
+
+          MSG="No ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN secret reached the Claude review workflow."
+          if [ -n "${ENV_NAME}" ]; then
+            MSG="${MSG} The '${ENV_NAME}' environment was selected — check that the secret exists in that environment and that the caller passes 'secrets: inherit'."
+          else
+            MSG="${MSG} Set a repo secret (gh secret set ANTHROPIC_API_KEY) and pass it via 'secrets:', or use a GitHub environment via the 'environment' input plus 'secrets: inherit'."
+          fi
+
+          if [ "${STRICT}" = "true" ]; then
+            echo "::error title=Claude code review: missing credentials::${MSG}"
+            exit 1
+          fi
+          echo "::notice title=Claude code review skipped: missing credentials::${MSG}"
+
+      - name: Checkout code
+        if: steps.gate.outputs.has-credentials == 'true'
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - name: Run Claude Code review
+        id: review
+        if: steps.gate.outputs.has-credentials == 'true'
+        continue-on-error: ${{ !inputs.strict }}
+        uses: anthropics/claude-code-action@v1
         with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           prompt: |
-            Review this PR. Focus on what matters for a reusable-workflow library
-            that consumers pin at @main (changes ship to all consumers on merge):
-            - correctness bugs in workflow YAML and embedded shell (set -euo pipefail
-              pitfalls, quoting, commands that legitimately exit non-zero)
-            - breaking changes to workflow/action inputs, outputs, or secrets
-            - drift between the change and the README docs or examples/ callers
-            - security issues (secret handling, injection via untrusted inputs)
-          claude_args: "--max-turns 8"
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for:
+            - Correctness bugs and unhandled edge cases
+            - Security issues (injection, secrets handling, authz)
+            - Significant performance problems
+            - Clarity or maintainability issues worth fixing now
+
+            Be concise and high-signal; skip nitpicks and style preferences.
+            Use inline comments for line-specific findings, then post a short
+            summary (overall assessment plus any blocking items).
+
+            ${{ inputs.review-prompt }}
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
+
+      - name: Report incomplete review
+        if: steps.gate.outputs.has-credentials == 'true' && steps.review.outcome == 'failure'
+        run: |
+          echo "::notice title=Claude code review did not complete::The review step failed — see its logs above. The job still passes because strict mode is off; set 'strict: true' to fail the job instead."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,10 @@ consumed by other repos. `examples/` holds copy-paste caller workflows for consu
   + `plugins/cicd-toolkit/skills/`). When a workflow's inputs, secrets, or the
   integration flow change, check the plugin skills for drift too — they're the
   guidance consumer repos' agents receive.
-- Every PR is auto-reviewed by `claude-review.yml` (posts one sticky comment;
-  requires the `CLAUDE_CODE_OAUTH_TOKEN` secret, generated via `claude setup-token`).
+- `claude-review.yml` is a **reusable** (`workflow_call`) Claude review workflow
+  consumers call like any other; `claude-review-self.yml` dogfoods it on this repo's
+  own PRs (inline + sticky comments; skips bot PRs; needs the `CLAUDE_CODE_OAUTH_TOKEN`
+  or `ANTHROPIC_API_KEY` secret). Changing its inputs is a consumer-facing change.
 - Secrets never touch a Claude session — not pasted into chat, not composed into
   commands, not run via the `!` prefix. The user runs
   `pbpaste | gh secret set <NAME> -R KotaHusky/cicd-toolkit` in their own terminal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ consumed by other repos. `examples/` holds copy-paste caller workflows for consu
 - Pushing a `v*` tag triggers `release.yml`, which calls the Anthropic API
   (`ANTHROPIC_API_KEY` secret) to generate release notes. Only tag when cutting a release.
 
+## Claude Tooling in This Repo
+- This repo hosts a Claude Code plugin marketplace (`.claude-plugin/marketplace.json`
+  + `plugins/cicd-toolkit/skills/`). When a workflow's inputs, secrets, or the
+  integration flow change, check the plugin skills for drift too — they're the
+  guidance consumer repos' agents receive.
+- Every PR is auto-reviewed by `claude-review.yml` (posts one sticky comment;
+  requires the `CLAUDE_CODE_OAUTH_TOKEN` secret, generated via `claude setup-token`).
+- Secrets are set via clipboard pipe, never pasted into chat or composed into
+  commands: user runs `! pbpaste | gh secret set <NAME> -R KotaHusky/cicd-toolkit`.
+
 ## Git Worktree Rules (MANDATORY)
 - **NEVER work directly on `main`**. Always create a feature branch.
 - **Use git worktrees** for parallel work: `git worktree add ../<repo>-<feature> -b feat/<feature>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,26 @@
 # CLAUDE.md
 
+## What This Repo Is
+Reusable GitHub Actions workflows (`.github/workflows/`, all `workflow_call`),
+composite actions (`actions/*/action.yml`), and AWS CDK constructs/stacks (`lib/`)
+consumed by other repos. `examples/` holds copy-paste caller workflows for consumers.
+
+## Working on Workflows & Actions
+- Workflows cannot be run locally. Consumers reference this repo at `@main`, so
+  merging to `main` ships to all consumers immediately. Test from a consumer repo
+  pointed at your branch: `uses: KotaHusky/cicd-toolkit/.github/workflows/<wf>.yml@<branch>`.
+- Shell steps run under `set -euo pipefail` — commands that legitimately exit
+  non-zero (e.g. `grep` with no match) need explicit guards.
+- When changing a workflow's or action's inputs/outputs, update its README section
+  and the matching file in `examples/`.
+
+## CDK Library & Releases
+- No barrel `lib/index.ts` — consumers deep-import from `lib/constructs/*` and
+  `lib/stacks/*`. Don't add one.
+- No lockfile is committed, by design — don't add `package-lock.json`.
+- Pushing a `v*` tag triggers `release.yml`, which calls the Anthropic API
+  (`ANTHROPIC_API_KEY` secret) to generate release notes. Only tag when cutting a release.
+
 ## Git Worktree Rules (MANDATORY)
 - **NEVER work directly on `main`**. Always create a feature branch.
 - **Use git worktrees** for parallel work: `git worktree add ../<repo>-<feature> -b feat/<feature>`
@@ -18,5 +39,5 @@
 - Each agent works in its own git worktree (see worktree rules above)
 - Agents must not modify files another agent is working on
 - Before starting, check `git worktree list` for conflicts
-- Use conventional commit messages
+- Use conventional commit messages, scoped to the workflow/action/construct touched (e.g. `fix(static-s3-deploy): ...`)
 - After completing work, create a PR — do not merge directly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ consumed by other repos. `examples/` holds copy-paste caller workflows for consu
   guidance consumer repos' agents receive.
 - Every PR is auto-reviewed by `claude-review.yml` (posts one sticky comment;
   requires the `CLAUDE_CODE_OAUTH_TOKEN` secret, generated via `claude setup-token`).
-- Secrets are set via clipboard pipe, never pasted into chat or composed into
-  commands: user runs `! pbpaste | gh secret set <NAME> -R KotaHusky/cicd-toolkit`.
+- Secrets never touch a Claude session — not pasted into chat, not composed into
+  commands, not run via the `!` prefix. The user runs
+  `pbpaste | gh secret set <NAME> -R KotaHusky/cicd-toolkit` in their own terminal.
 
 ## Git Worktree Rules (MANDATORY)
 - **NEVER work directly on `main`**. Always create a feature branch.

--- a/README.md
+++ b/README.md
@@ -273,6 +273,17 @@ See [`examples/`](examples/) for ready-to-copy workflow files:
 - [`release.yml`](examples/release.yml) — AI-powered release on tag push
 - [`static-site.yml`](examples/static-site.yml) — Tag-driven release for an S3+CloudFront static site
 
+## Claude Code plugin
+
+This repo hosts a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugins). Installing the plugin gives Claude, in any consumer repo, skills for picking the right workflow, wiring up the caller file, setting secrets securely, and bootstrapping AWS OIDC:
+
+```
+/plugin marketplace add KotaHusky/cicd-toolkit
+/plugin install cicd-toolkit@cicd-toolkit
+```
+
+Skills: `/integrate-cicd-toolkit`, `/bootstrap-oidc`.
+
 ## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -282,7 +282,14 @@ This repo hosts a [Claude Code plugin marketplace](https://code.claude.com/docs/
 /plugin install cicd-toolkit@cicd-toolkit
 ```
 
-Skills: `/integrate-cicd-toolkit`, `/bootstrap-oidc`.
+| Skill | What it does |
+|---|---|
+| `/integrate-cicd-toolkit` | Picks the right workflow, adapts a caller from `examples/`, and walks through secrets setup — including generating a `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token` and storing any secret with a clipboard pipe (`pbpaste \| gh secret set …`) so values never enter the AI conversation. |
+| `/bootstrap-oidc` | One-time GitHub → AWS OIDC provisioning via `bin/bootstrap.ts` (provider + deploy role), producing the `AWS_DEPLOY_ROLE_ARN` secret used by the AWS deploy workflows. |
+
+## Claude PR review
+
+Every PR to this repo is automatically reviewed by [`claude-review.yml`](.github/workflows/claude-review.yml) (`anthropics/claude-code-action@v1`), which posts a single sticky comment covering shell/workflow pitfalls, breaking input changes, and README/`examples/` drift. It requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret, generated with `claude setup-token`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -284,12 +284,12 @@ This repo hosts a [Claude Code plugin marketplace](https://code.claude.com/docs/
 
 | Skill | What it does |
 |---|---|
-| `/integrate-cicd-toolkit` | Picks the right workflow, adapts a caller from `examples/`, and walks through secrets setup — including generating a `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token` and storing any secret with a clipboard pipe (`pbpaste \| gh secret set …`) so values never enter the AI conversation. |
+| `/integrate-cicd-toolkit` | Picks the right workflow, adapts a caller from `examples/`, and walks through secrets setup — including generating a `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token` and storing any secret with a clipboard pipe (`pbpaste \| gh secret set …`) run in your own terminal, outside the Claude session, so values never enter the AI conversation. |
 | `/bootstrap-oidc` | One-time GitHub → AWS OIDC provisioning via `bin/bootstrap.ts` (provider + deploy role), producing the `AWS_DEPLOY_ROLE_ARN` secret used by the AWS deploy workflows. |
 
 ## Claude PR review
 
-Every PR to this repo is automatically reviewed by [`claude-review.yml`](.github/workflows/claude-review.yml) (`anthropics/claude-code-action@v1`), which posts a single sticky comment covering shell/workflow pitfalls, breaking input changes, and README/`examples/` drift. It requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret, generated with `claude setup-token`.
+Every PR to this repo is automatically reviewed by [`claude-review.yml`](.github/workflows/claude-review.yml) (`anthropics/claude-code-action@v1`), which posts a single sticky comment covering shell/workflow pitfalls, breaking input changes, and README/`examples/` drift. It requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret — run `claude setup-token` in a terminal, copy the token, then `pbpaste | gh secret set CLAUDE_CODE_OAUTH_TOKEN -R KotaHusky/cicd-toolkit` (all outside any Claude session).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,53 @@ jobs:
 
 The workflow compares commits between the current and previous semver tags, sends the log to Claude, and creates a release titled `v1.2.0 — <AI-generated title>` with a summary and full changelog.
 
+### Claude Code Review
+
+**`claude-review.yml`** — Automated Claude review on pull requests via [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action). Posts inline comments for line-specific findings plus one sticky summary comment that updates on new pushes.
+
+Requires the [Claude GitHub App](https://github.com/apps/claude) to be installed on the consuming repo.
+
+```yaml
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+jobs:
+  review:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/claude-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+To source the key from a GitHub environment in the consuming repo instead of a repo secret, pass the environment name and inherit secrets (environment secrets only resolve with `secrets: inherit`):
+
+```yaml
+    with:
+      environment: claude
+    secrets: inherit
+```
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `environment` | string | `''` | GitHub environment (in the calling repo) to source secrets from; requires `secrets: inherit` |
+| `model` | string | `''` | Claude model override; empty uses the action default |
+| `review-prompt` | string | `''` | Extra project-specific review instructions |
+| `max-turns` | string | `25` | Max agent turns per review (cost control) |
+| `strict` | boolean | `false` | Fail the job when the review can't run (missing credentials or a review error); default is a notice annotation and a passing job |
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `ANTHROPIC_API_KEY` | one of | Anthropic API key (pay-per-token billing) |
+| `CLAUDE_CODE_OAUTH_TOKEN` | one of | Claude Pro/Max OAuth token from `claude setup-token` (uses subscription quota) |
+
+The review is advisory by default: if no credentials are available, or the review step itself errors, the run emits a **notice annotation** and the job still passes — the caller's CI is never blocked. Set `strict: true` to fail the job with an **error annotation** instead.
+
 ## Setup
 
 ### Secrets
@@ -182,14 +229,14 @@ The workflow compares commits between the current and previous semver tags, send
 Consumer repos need to configure the following secrets depending on which workflows they use:
 
 ```bash
-# For AI-powered releases (release.yml)
+# For AI-powered releases (release.yml) and Claude code review (claude-review.yml)
 gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
 
 # For CDK deployments (cdk-deploy.yml)
 gh secret set AWS_DEPLOY_ROLE_ARN --repo <owner>/<repo>
 ```
 
-Generate your Anthropic API key at [console.anthropic.com](https://console.anthropic.com/) under API Keys.
+Generate your Anthropic API key at [console.anthropic.com](https://console.anthropic.com/) under API Keys. For `claude-review.yml`, also install the [Claude GitHub App](https://github.com/apps/claude) on the repo; Claude Pro/Max subscribers can set `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) instead of an API key to draw on subscription usage rather than per-token billing.
 
 ### OIDC Bootstrap (CDK Deploy)
 
@@ -289,7 +336,7 @@ This repo hosts a [Claude Code plugin marketplace](https://code.claude.com/docs/
 
 ## Claude PR review
 
-Every PR to this repo is automatically reviewed by [`claude-review.yml`](.github/workflows/claude-review.yml) (`anthropics/claude-code-action@v1`), which posts a single sticky comment covering shell/workflow pitfalls, breaking input changes, and README/`examples/` drift. It requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret — run `claude setup-token` in a terminal, copy the token, then `pbpaste | gh secret set CLAUDE_CODE_OAUTH_TOKEN -R KotaHusky/cicd-toolkit` (all outside any Claude session).
+Every PR to this repo is automatically reviewed by [`claude-review-self.yml`](.github/workflows/claude-review-self.yml), which dogfoods the reusable [`claude-review.yml`](.github/workflows/claude-review.yml) documented in [Workflows](#claude-code-review) — inline comments for line-specific findings plus one sticky summary, with a prompt tuned for reusable-workflow risks (shell pitfalls, breaking input changes, README/`examples/`/skills drift). Bot PRs are skipped. Credentials: the `CLAUDE_CODE_OAUTH_TOKEN` repo secret — run `claude setup-token` in a terminal, copy the token, then `pbpaste | gh secret set CLAUDE_CODE_OAUTH_TOKEN -R KotaHusky/cicd-toolkit` (all outside any Claude session).
 
 ## License
 

--- a/examples/claude-review.yml
+++ b/examples/claude-review.yml
@@ -1,0 +1,51 @@
+# Example Claude code review pipeline using cicd-toolkit.
+# Copy this file to your repo at .github/workflows/claude-review.yml and adjust as needed.
+#
+# Prerequisites:
+#   1. Install the Claude GitHub App on the repo: https://github.com/apps/claude
+#   2. Provide Anthropic credentials (choose one):
+#      - Repo secret:        gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
+#      - Environment secret: put ANTHROPIC_API_KEY in a GitHub environment and
+#        pass `environment: <name>` with `secrets: inherit` (see below)
+#      - Claude Pro/Max:     gh secret set CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`)
+#
+# The review is advisory: if credentials are missing or the review errors, the
+# run posts a notice annotation and the job still passes. Set strict: true to
+# fail the job instead.
+
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+jobs:
+  review:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/claude-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    # with:
+    #   model: 'claude-sonnet-4-6'     # override the default model
+    #   max-turns: '15'                # tighten the cost cap
+    #   strict: true                   # fail the job if the review can't run
+    #   review-prompt: |               # project-specific focus areas
+    #     Pay extra attention to the public API surface in src/api/.
+
+  # --- Alternative: source the key from a GitHub environment ---
+  # review:
+  #   uses: KotaHusky/cicd-toolkit/.github/workflows/claude-review.yml@main
+  #   permissions:
+  #     contents: read
+  #     pull-requests: write
+  #     issues: read
+  #     id-token: write
+  #     actions: read
+  #   with:
+  #     environment: claude   # environment in YOUR repo holding ANTHROPIC_API_KEY
+  #   secrets: inherit        # required for environment secrets to resolve

--- a/plugins/cicd-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cicd-toolkit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "cicd-toolkit",
+  "version": "0.1.0",
+  "description": "Integrate KotaHusky/cicd-toolkit reusable GitHub Actions workflows, composite actions, and AWS CDK constructs into a consumer repo — workflow selection, secrets setup, and OIDC bootstrap.",
+  "author": {
+    "name": "KotaHusky"
+  }
+}

--- a/plugins/cicd-toolkit/skills/bootstrap-oidc/SKILL.md
+++ b/plugins/cicd-toolkit/skills/bootstrap-oidc/SKILL.md
@@ -14,7 +14,7 @@ description: One-time AWS setup so a GitHub repo can deploy via cicd-toolkit's A
 ## Procedure
 
 1. Clone (or work from) `KotaHusky/cicd-toolkit`. Read `bin/bootstrap.ts` first — the org name and per-repo role/policy configuration live there; confirm the target org/repos with the user before deploying.
-2. Confirm AWS credentials for the *target account* are active locally (`aws sts get-caller-identity`). If not, the user must authenticate first (e.g. `! aws sso login`).
+2. Confirm AWS credentials for the *target account* are active locally (`aws sts get-caller-identity`). If not, the user must authenticate first in their own terminal (e.g. `aws sso login` — it's interactive browser auth, so it won't run under a session shell).
 3. Deploy the bootstrap stack:
 
    ```sh
@@ -22,13 +22,14 @@ description: One-time AWS setup so a GitHub repo can deploy via cicd-toolkit's A
    ```
 
 4. Capture the role ARN from the stack outputs.
-5. Store it in the consumer repo **without pasting it into chat** — have the user copy the ARN and run:
+5. Store it in the consumer repo **without pasting it into chat** — have the user copy the ARN and run, in their own terminal outside the Claude session:
 
-   ```
-   ! pbpaste | gh secret set AWS_DEPLOY_ROLE_ARN -R <owner>/<repo>
+   ```sh
+   # user's own terminal — not inside the Claude session
+   pbpaste | gh secret set AWS_DEPLOY_ROLE_ARN -R <owner>/<repo>
    ```
 
-   (Role ARNs are only mildly sensitive, but use the same pipe habit as for real secrets.)
+   (Role ARNs are only mildly sensitive, but keep the same out-of-session habit as for real secrets.)
 
 6. Verify: trigger the consumer's deploy workflow and confirm the `Configure AWS credentials` step assumes the role successfully.
 

--- a/plugins/cicd-toolkit/skills/bootstrap-oidc/SKILL.md
+++ b/plugins/cicd-toolkit/skills/bootstrap-oidc/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: bootstrap-oidc
+description: One-time AWS setup so a GitHub repo can deploy via cicd-toolkit's AWS workflows (cdk-deploy, static-s3-deploy, ECS) using OIDC instead of static credentials. Use when a consumer repo hits missing AWS_DEPLOY_ROLE_ARN, "not authorized to perform sts:AssumeRoleWithWebIdentity", or is adopting an AWS deploy workflow for the first time.
+---
+
+# Bootstrap GitHub → AWS OIDC
+
+`cicd-toolkit` deploys to AWS by assuming an IAM role via GitHub's OIDC provider — no long-lived AWS keys. This bootstrap provisions, once per AWS account:
+
+1. An IAM OIDC provider for `token.actions.githubusercontent.com`
+2. An IAM role trusted by the GitHub org/repo(s), with deployment policies
+3. Outputs the role ARN consumers store as the `AWS_DEPLOY_ROLE_ARN` secret
+
+## Procedure
+
+1. Clone (or work from) `KotaHusky/cicd-toolkit`. Read `bin/bootstrap.ts` first — the org name and per-repo role/policy configuration live there; confirm the target org/repos with the user before deploying.
+2. Confirm AWS credentials for the *target account* are active locally (`aws sts get-caller-identity`). If not, the user must authenticate first (e.g. `! aws sso login`).
+3. Deploy the bootstrap stack:
+
+   ```sh
+   npx cdk deploy --app "npx ts-node bin/bootstrap.ts"
+   ```
+
+4. Capture the role ARN from the stack outputs.
+5. Store it in the consumer repo **without pasting it into chat** — have the user copy the ARN and run:
+
+   ```
+   ! pbpaste | gh secret set AWS_DEPLOY_ROLE_ARN -R <owner>/<repo>
+   ```
+
+   (Role ARNs are only mildly sensitive, but use the same pipe habit as for real secrets.)
+
+6. Verify: trigger the consumer's deploy workflow and confirm the `Configure AWS credentials` step assumes the role successfully.
+
+## Gotchas
+
+- One OIDC provider per AWS account — if `token.actions.githubusercontent.com` already exists, the stack must import/reuse it rather than create a duplicate.
+- The role's trust policy scopes which repos/branches may assume it. A new consumer repo usually means editing `bin/bootstrap.ts` and re-deploying, not creating a new provider.
+- CDK deploys additionally require the account to be CDK-bootstrapped (`npx cdk bootstrap`) in the target region.

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -34,6 +34,7 @@ Adapt the example rather than authoring a caller from scratch.
 | Static site (Next.js/Astro/Vite) → S3 + CloudFront | `static-s3-deploy.yml` |
 | Node/Express app → ECS Fargate | `ecs-express-deploy.yml` / `ecs-express-app-deploy.yml` |
 | GitHub Release with AI-generated notes on `v*` tag | `release.yml` |
+| Claude AI review on every PR (inline + sticky summary) | `claude-review.yml` — needs the [Claude GitHub App](https://github.com/apps/claude) installed and `ANTHROPIC_API_KEY` **or** `CLAUDE_CODE_OAUTH_TOKEN`; advisory by default (never blocks CI), `strict: true` to enforce |
 | Semver tag automation | `semver-tag.yml` |
 | Azure Container Apps | `aca-provision.yml`, `aca-deploy.yml` |
 | Cloudflare DNS management | `cloudflare-dns.yml` |

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -68,7 +68,35 @@ Determine which secrets the chosen workflow needs (from the fetched README). Com
 
 The value flows clipboard → gh → GitHub's encrypted store without appearing in the conversation, terminal scrollback, or shell history. On Linux replace `pbpaste` with `xclip -selection clipboard -o` or `wl-paste`.
 
-Note: Anthropic API keys cannot be created programmatically — the Admin API only lists/updates existing keys. The user must create the key at console.anthropic.com, then use the pipe above. For Claude Code OAuth tokens, `claude setup-token` generates the value locally; store it the same way.
+For Claude/Anthropic tokens specifically, follow the flows in the next section.
+
+## Claude token setup (reviewer / release workflows)
+
+Two token types, two flows — both end with the same secure pipe. Ask which the user
+wants if unclear: OAuth token uses a Claude Pro/Max subscription; API key bills per-token.
+
+**`CLAUDE_CODE_OAUTH_TOKEN`** — used by `anthropics/claude-code-action` workflows
+(e.g. cicd-toolkit's own `claude-review.yml`). This one *can* be generated locally:
+
+1. Have the user run `! claude setup-token` — it opens browser auth and prints a
+   long-lived OAuth token (requires a Claude Pro/Max subscription).
+2. Have them copy the token, then run:
+
+   ```
+   ! pbpaste | gh secret set CLAUDE_CODE_OAUTH_TOKEN -R <owner>/<repo>
+   ```
+
+**`ANTHROPIC_API_KEY`** — used by `release.yml` for AI release notes. API keys
+**cannot** be created programmatically (the Admin API only lists/renames/disables
+existing keys), so:
+
+1. The user creates a key at https://console.anthropic.com/settings/keys and copies it.
+2. ```
+   ! pbpaste | gh secret set ANTHROPIC_API_KEY -R <owner>/<repo>
+   ```
+
+Verify either with `gh secret list -R <owner>/<repo>` — names and timestamps only;
+values are never readable back, which is the point.
 
 ## Gotchas
 

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -60,40 +60,44 @@ Determine which secrets the chosen workflow needs (from the fetched README). Com
 - `TURBO_TOKEN` / `TURBO_TEAM` — optional, Turbo remote cache.
 - `NODE_AUTH_TOKEN` — optional, private GitHub Packages during builds.
 
-**Handoff procedure (mandatory):** never ask the user to paste a secret into chat, and never echo one into a command you compose. Instead, have the user copy the value (from the Anthropic Console, AWS output, etc.) and run this themselves via the `!` shell prefix:
+**Handoff procedure (mandatory):** secret handling happens entirely **outside the Claude session** — never ask the user to paste a secret into chat, never compose a command containing one, and don't run the storage command yourself (not even via the `!` prefix; keeping the whole flow out of the session guarantees no secret can enter the conversation). Have the user copy the value (from the Anthropic Console, AWS output, etc.) and run this **in their own terminal**:
 
-```
-! pbpaste | gh secret set <SECRET_NAME> -R <owner>/<repo>
+```sh
+# user's own terminal — not inside the Claude session
+pbpaste | gh secret set <SECRET_NAME> -R <owner>/<repo>
 ```
 
-The value flows clipboard → gh → GitHub's encrypted store without appearing in the conversation, terminal scrollback, or shell history. On Linux replace `pbpaste` with `xclip -selection clipboard -o` or `wl-paste`.
+The value flows clipboard → gh → GitHub's encrypted store without ever being displayed or entering shell history. On Linux replace `pbpaste` with `xclip -selection clipboard -o` or `wl-paste`.
 
 For Claude/Anthropic tokens specifically, follow the flows in the next section.
 
 ## Claude token setup (reviewer / release workflows)
 
-Two token types, two flows — both end with the same secure pipe. Ask which the user
+Two token types, two flows. Both run **entirely in the user's own terminal, outside
+the Claude session** (per the handoff procedure above; `claude setup-token` is also
+interactive — browser auth — and won't run under a session shell). Ask which the user
 wants if unclear: OAuth token uses a Claude Pro/Max subscription; API key bills per-token.
 
 **`CLAUDE_CODE_OAUTH_TOKEN`** — used by `anthropics/claude-code-action` workflows
-(e.g. cicd-toolkit's own `claude-review.yml`). This one *can* be generated locally:
+(e.g. cicd-toolkit's own `claude-review.yml`). This one *can* be generated locally.
+Give the user these steps to run in their own terminal:
 
-1. Have the user run `! claude setup-token` — it opens browser auth and prints a
-   long-lived OAuth token (requires a Claude Pro/Max subscription).
-2. Have them copy the token, then run:
-
-   ```
-   ! pbpaste | gh secret set CLAUDE_CODE_OAUTH_TOKEN -R <owner>/<repo>
-   ```
+```sh
+# user's own terminal — not inside the Claude session
+claude setup-token   # browser auth; prints a long-lived OAuth token (Pro/Max required)
+# copy the printed token, then:
+pbpaste | gh secret set CLAUDE_CODE_OAUTH_TOKEN -R <owner>/<repo>
+```
 
 **`ANTHROPIC_API_KEY`** — used by `release.yml` for AI release notes. API keys
 **cannot** be created programmatically (the Admin API only lists/renames/disables
-existing keys), so:
+existing keys). The user creates a key at https://console.anthropic.com/settings/keys,
+copies it, then in their own terminal:
 
-1. The user creates a key at https://console.anthropic.com/settings/keys and copies it.
-2. ```
-   ! pbpaste | gh secret set ANTHROPIC_API_KEY -R <owner>/<repo>
-   ```
+```sh
+# user's own terminal — not inside the Claude session
+pbpaste | gh secret set ANTHROPIC_API_KEY -R <owner>/<repo>
+```
 
 Verify either with `gh secret list -R <owner>/<repo>` — names and timestamps only;
 values are never readable back, which is the point.

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: integrate-cicd-toolkit
+description: Integrate KotaHusky/cicd-toolkit reusable workflows and composite actions into the current repo — pick the right workflow, wire up the caller file, and set required secrets securely. Use when adding CI/CD (build verification, commitlint, Docker/GHCR, CDK deploys, static-site S3/CloudFront deploys, ECS Express deploys, AI-generated releases) to a repo that consumes cicd-toolkit.
+---
+
+# Integrate cicd-toolkit
+
+You are wiring the current repo up to reusable workflows from `KotaHusky/cicd-toolkit`.
+
+## Step 1: Fetch the current docs — do not rely on memorized inputs
+
+Workflow inputs/outputs change; the toolkit README is the source of truth. Fetch it fresh:
+
+```
+https://raw.githubusercontent.com/KotaHusky/cicd-toolkit/main/README.md
+```
+
+For a ready-to-copy caller file, list `examples/` in the repo and fetch the one matching the chosen workflow:
+
+```
+https://api.github.com/repos/KotaHusky/cicd-toolkit/contents/examples
+```
+
+Adapt the example rather than authoring a caller from scratch.
+
+## Step 2: Pick the workflow
+
+| Consumer need | Workflow |
+|---|---|
+| PR build/test/lint for Node (Turborepo-aware) | `build-verify.yml` |
+| Enforce Conventional Commits on PRs | `commitlint.yml` |
+| Build + push Docker image to GHCR | `docker-ghcr.yml` |
+| Deploy AWS CDK app (OIDC auth) | `cdk-deploy.yml` (synth-only check: `cdk-synth.yml`) |
+| Static site (Next.js/Astro/Vite) → S3 + CloudFront | `static-s3-deploy.yml` |
+| Node/Express app → ECS Fargate | `ecs-express-deploy.yml` / `ecs-express-app-deploy.yml` |
+| GitHub Release with AI-generated notes on `v*` tag | `release.yml` |
+| Semver tag automation | `semver-tag.yml` |
+| Azure Container Apps | `aca-provision.yml`, `aca-deploy.yml` |
+| Cloudflare DNS management | `cloudflare-dns.yml` |
+
+Reference pattern (all are `workflow_call`):
+
+```yaml
+jobs:
+  ci:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/<workflow>.yml@main
+    with: ...
+    secrets: ...
+```
+
+Composite actions (`turbo-setup`, `ecr-mirror`, `cfn-recover`) are referenced as
+`uses: KotaHusky/cicd-toolkit/actions/<action>@main` inside a consumer's own job steps.
+
+## Step 3: Secrets — never let a secret enter the conversation
+
+Determine which secrets the chosen workflow needs (from the fetched README). Common ones:
+
+- `AWS_DEPLOY_ROLE_ARN` — for any AWS deploy workflow; produced by the OIDC bootstrap (see the `bootstrap-oidc` skill). No static AWS keys, ever.
+- `ANTHROPIC_API_KEY` — for `release.yml` AI release notes.
+- `TURBO_TOKEN` / `TURBO_TEAM` — optional, Turbo remote cache.
+- `NODE_AUTH_TOKEN` — optional, private GitHub Packages during builds.
+
+**Handoff procedure (mandatory):** never ask the user to paste a secret into chat, and never echo one into a command you compose. Instead, have the user copy the value (from the Anthropic Console, AWS output, etc.) and run this themselves via the `!` shell prefix:
+
+```
+! pbpaste | gh secret set <SECRET_NAME> -R <owner>/<repo>
+```
+
+The value flows clipboard → gh → GitHub's encrypted store without appearing in the conversation, terminal scrollback, or shell history. On Linux replace `pbpaste` with `xclip -selection clipboard -o` or `wl-paste`.
+
+Note: Anthropic API keys cannot be created programmatically — the Admin API only lists/updates existing keys. The user must create the key at console.anthropic.com, then use the pipe above. For Claude Code OAuth tokens, `claude setup-token` generates the value locally; store it the same way.
+
+## Gotchas
+
+- Consumers pin `@main` — toolkit changes ship to this repo immediately on merge upstream. Pin a tag or SHA if the consumer needs stability.
+- Grant each caller job the `permissions:` block shown in the toolkit README for that workflow (OIDC deploys need `id-token: write`).
+- `release.yml` and `commitlint.yml` assume Conventional Commit messages.
+- Verify by opening a small PR (or pushing a tag for release flows) and watching the run — reusable workflows can't be executed locally.


### PR DESCRIPTION
## Summary
- **Plugin marketplace hosted in-repo** (`.claude-plugin/marketplace.json` + `plugins/cicd-toolkit/`): consumer repos run `/plugin marketplace add KotaHusky/cicd-toolkit` then `/plugin install cicd-toolkit@cicd-toolkit` to give their Claude sessions two skills:
  - `integrate-cicd-toolkit` — workflow selection table, caller wiring from `examples/`, and a secure clipboard→`gh secret set` handoff so secrets never enter the conversation. Fetches the README at use time to avoid input drift.
  - `bootstrap-oidc` — the `bin/bootstrap.ts` OIDC provisioning runbook (provider reuse, trust-policy scoping, CDK bootstrap prerequisite).
- **Claude auto-reviewer** (`.github/workflows/claude-review.yml`): `anthropics/claude-code-action@v1` on every PR open/synchronize, sticky consolidated comment, prompt tuned for this repo's risks (pipefail/shell pitfalls, breaking workflow-input changes, README/`examples/` drift). Skips bot PRs.
- **CLAUDE.md** now documents repo-specific guidance (consumers pin `@main`, no lockfile by design, no `lib/index.ts` barrel, `v*` tags trigger the AI release).

## Setup required before the reviewer runs
The workflow needs the `CLAUDE_CODE_OAUTH_TOKEN` secret:
1. `claude setup-token` (generates a Pro/Max OAuth token locally)
2. Copy the token, then: `pbpaste | gh secret set CLAUDE_CODE_OAUTH_TOKEN -R KotaHusky/cicd-toolkit`

## Test plan
- [x] `npm test` — 42/42 pass
- [x] `jq` validation of marketplace.json / plugin.json; YAML parse of claude-review.yml
- [ ] After merge: `/plugin marketplace add KotaHusky/cicd-toolkit` from a consumer repo and confirm both skills load
- [ ] Set `CLAUDE_CODE_OAUTH_TOKEN`, open a trivial PR, confirm the sticky review comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)