### PR TITLE
feat(build-verify): embed advisory Claude review job

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -28,9 +28,27 @@ on:
         required: false
         type: string
         default: 'npm'
+      claude-review:
+        description: >-
+          Run an advisory Claude AI review on pull requests. Activates only
+          when an Anthropic secret is provided; skips silently otherwise.
+        required: false
+        type: boolean
+        default: true
+      claude-review-prompt:
+        description: 'Extra project-specific review instructions appended to the default review prompt'
+        required: false
+        type: string
+        default: ''
     secrets:
       node-auth-token:
         description: 'Token for installing private GitHub Packages (npm) deps. Optional.'
+        required: false
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key for the Claude review. Optional — review is skipped without credentials.'
+        required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: 'Claude Pro/Max OAuth token for the Claude review. Optional — review is skipped without credentials.'
         required: false
 
 concurrency:
@@ -152,3 +170,61 @@ jobs:
 
       - name: Lint
         run: npx turbo run lint
+
+  claude-review:
+    # Advisory AI review — designed to never break a consumer build:
+    # no job-level permissions block (inherits the caller's grant, so no
+    # plan-time permission failures), a credential gate that skips with a
+    # notice, and continue-on-error on the review itself. If the caller's
+    # token lacks pull-requests: write, the review degrades to a skip.
+    name: Claude Review
+    if: >-
+      ${{ inputs.claude-review &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check for Anthropic credentials
+        id: gate
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${ANTHROPIC_API_KEY}" ] || [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has-credentials=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-credentials=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Claude review skipped::No ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN secret reached build-verify. Pass one via 'secrets:' (or use 'secrets: inherit') to enable AI review, or set 'claude-review: false' to silence this notice."
+          fi
+
+      - name: Checkout code
+        if: steps.gate.outputs.has-credentials == 'true'
+        uses: actions/checkout@v7
+
+      - name: Run Claude Code review (advisory)
+        if: steps.gate.outputs.has-credentials == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for:
+            - Correctness bugs and unhandled edge cases
+            - Security issues (injection, secrets handling, authz)
+            - Significant performance problems
+            - Clarity or maintainability issues worth fixing now
+
+            Be concise and high-signal; skip nitpicks and style preferences.
+            Use inline comments for line-specific findings, then post a short
+            summary (overall assessment plus any blocking items).
+
+            ${{ inputs.claude-review-prompt }}
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 25

--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ jobs:
 | `run-tests` | boolean | `true` | Run the test step |
 | `run-lint` | boolean | `true` | Run the lint step |
 | `package-manager` | string | `npm` | Package manager (`npm` or `pnpm`) |
+| `claude-review` | boolean | `true` | Advisory Claude AI review on PRs; activates only when an Anthropic secret is passed |
+| `claude-review-prompt` | string | `''` | Extra project-specific review instructions |
+
+**Built-in Claude review:** when the caller passes `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (directly or via `secrets: inherit`), pull requests get an advisory AI review (inline comments + sticky summary) with no extra workflow file. It never blocks CI: no credentials → skip with a notice; insufficient permissions → the review step is swallowed. For comments to post, grant the calling job `pull-requests: write` (see [Claude Code Review](#claude-code-review) for the standalone workflow and full permission block). Requires the [Claude GitHub App](https://github.com/apps/claude) on the repo. Set `claude-review: false` to opt out.
+
+```yaml
+jobs:
+  verify:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/build-verify.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
 
 ### Commitlint
 

--- a/examples/ci.yml
+++ b/examples/ci.yml
@@ -16,8 +16,23 @@ jobs:
 
   verify:
     uses: KotaHusky/cicd-toolkit/.github/workflows/build-verify.yml@main
+    # Permissions enable the built-in advisory Claude review to post PR
+    # comments. The review activates only when an Anthropic secret is passed
+    # below; without one it skips silently and these grants are harmless.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # pay-per-token alternative
     with:
       node-version: '24'
+      # claude-review: false          # opt out of the AI review
+      # claude-review-prompt: |       # project-specific review focus
+      #   Pay extra attention to src/api/.
       # run-build: false   # skip build step
       # run-tests: false   # skip test step
       # run-lint: false    # skip lint step


### PR DESCRIPTION
## Summary
- `build-verify.yml` gains a `claude-review` job: consumers already calling it on PRs get an advisory AI review (inline comments + sticky summary) with **zero new workflow files** — it activates when `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` is passed (`secrets: inherit` works too).
- Never breaks a consumer build, by construction: no job-level permissions (inherits caller grant → no plan-time permission failures), credential gate skips with a notice when no secret is present, and the review step runs `continue-on-error`. Bot PRs skipped.
- New inputs: `claude-review` (default `true`, opt-out) and `claude-review-prompt` (project-specific focus, appended to the default prompt).
- README build-verify section + `examples/ci.yml` document the permission block needed for comments to post.
- The standalone reusable `claude-review.yml` remains for repos that want review without build-verify (or with `strict` mode).

## Test plan
- [x] YAML parses; Actionlint/ShellCheck in CI
- [x] `npm test` 42/42
- [ ] After merge: open a PR in a consumer repo with the token set (all four have it) and confirm the review job posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)