### PR TITLE
chore(security): supply-chain hardening — SHA pins, provenance, Scorecard, schema versioning

### DIFF
--- a/.github/workflows/aca-deploy.yml
+++ b/.github/workflows/aca-deploy.yml
@@ -81,14 +81,14 @@ jobs:
       fqdn: ${{ steps.fqdn.outputs.fqdn }}
     steps:
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Container Apps
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
           resourceGroup: ${{ inputs.resource-group }}
           containerAppName: ${{ inputs.container-app-name }}

--- a/.github/workflows/aca-provision.yml
+++ b/.github/workflows/aca-provision.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: azure/login@v2
+      - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -58,7 +58,7 @@ jobs:
             --location "${{ inputs.location }}"
 
       - name: Deploy Bicep template
-        uses: azure/arm-deploy@v2
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2
         with:
           resourceGroupName: ${{ inputs.resource-group }}
           template: ${{ inputs.bicep-file }}

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -112,7 +112,7 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.5.0
+        uses: rharkor/caching-for-turbo@75f8ebf4a43d2c60b23bc2a27082cfea94ffdad9 # v2.5.0
 
       - name: Build
         run: npx turbo run build
@@ -139,7 +139,7 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.5.0
+        uses: rharkor/caching-for-turbo@75f8ebf4a43d2c60b23bc2a27082cfea94ffdad9 # v2.5.0
 
       - name: Test
         run: npx turbo run test
@@ -166,7 +166,7 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.5.0
+        uses: rharkor/caching-for-turbo@75f8ebf4a43d2c60b23bc2a27082cfea94ffdad9 # v2.5.0
 
       - name: Lint
         run: npx turbo run lint

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -96,7 +96,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
           pre-build-filter: ${{ inputs.pre-build-filter }}
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run ShellCheck on composite action scripts
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: './actions'
           severity: warning

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -59,6 +59,11 @@ jobs:
     timeout-minutes: 30
     environment: ${{ inputs.environment }}
     steps:
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        with:
+          egress-policy: audit
+
       # The `secrets` context is not allowed in job-level `if`, so gate in a step.
       - name: Check for Anthropic credentials
         id: gate

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -36,6 +36,14 @@ on:
         required: false
         type: string
         default: ''
+      provenance:
+        description: >-
+          BuildKit provenance attestation for pushed images: 'mode=max',
+          'mode=min', 'true', or 'false'. SLSA-aligned supply-chain metadata;
+          no extra caller permissions needed.
+        required: false
+        type: string
+        default: 'mode=max'
       whats-new-path:
         description: >-
           Bake the latest release's whats-new.json into the build context at
@@ -78,10 +86,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -98,7 +106,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ inputs.image-name || format('ghcr.io/{0}', github.repository) }}
           tags: |
@@ -125,7 +133,7 @@ jobs:
 
       - name: Build and push
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -133,6 +141,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ inputs.platforms }}
+          provenance: ${{ inputs.provenance }}
           build-args: ${{ inputs.build-args }}
           secrets: |
             node_auth_token=${{ secrets.node-auth-token }}

--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -180,7 +180,7 @@ jobs:
       # work without this). Writes ~/.docker/config.json, which crane reads.
       - name: Log in to GHCR
         run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.role-arn }}
           aws-region: ${{ inputs.aws-region }}
@@ -226,7 +226,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/ecs-express-deploy.yml
+++ b/.github/workflows/ecs-express-deploy.yml
@@ -148,7 +148,7 @@ jobs:
           ref: ${{ inputs.checkout-ref || github.ref }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.role-arn }}
           aws-region: ${{ inputs.aws-region }}
@@ -179,7 +179,7 @@ jobs:
 
       - name: Deploy to ECS Express Mode
         id: deploy
-        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        uses: aws-actions/amazon-ecs-deploy-express-service@7c48a2de16441d528a3c89829831968dc1455010 # v1
         with:
           service-name: ${{ inputs.service-name }}
           image: ${{ inputs.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,11 @@ jobs:
       release-url: ${{ steps.create-release.outputs.release-url }}
       previous-tag: ${{ steps.changelog.outputs.previous-tag }}
     steps:
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v7
         with:
@@ -244,6 +249,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v7
 
@@ -447,7 +457,7 @@ jobs:
             exit 1
           fi
 
-          jq --arg version "$VERSION" --arg date "$DATE"             '{version: $version, date: $date} + {title, summary, highlights}'             "$BODY_FILE" > /tmp/whats-new.json
+          jq --arg version "$VERSION" --arg date "$DATE"             '{schemaVersion: 1, version: $version, date: $date} + {title, summary, highlights}'             "$BODY_FILE" > /tmp/whats-new.json
           echo "Public summary:"
           cat /tmp/whats-new.json
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '30 8 * * 1' # weekly, Monday 08:30 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # publish results (public repos)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     uses: ./.github/workflows/release.yml
     secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   float-tags:

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Compute version & create tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ github.token }}
           default_bump: ${{ inputs.default-bump }}

--- a/.github/workflows/static-s3-deploy.yml
+++ b/.github/workflows/static-s3-deploy.yml
@@ -154,7 +154,7 @@ jobs:
         shell: bash
         run: ${{ inputs.build-command }}
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ consumed by other repos. `examples/` holds copy-paste caller workflows for consu
 - Workflows cannot be run locally. Consumers reference this repo at `@main`, so
   merging to `main` ships to all consumers immediately. Test from a consumer repo
   pointed at your branch: `uses: KotaHusky/cicd-toolkit/.github/workflows/<wf>.yml@<branch>`.
+- Third-party actions are pinned to commit SHAs with a `# <tag>` comment
+  (Dependabot keeps them fresh). Keep new `uses:` refs SHA-pinned, except
+  `actions/*` and `anthropics/*` which stay on tags.
 - Shell steps run under `set -euo pipefail` — commands that legitimately exit
   non-zero (e.g. `grep` with no match) need explicit guards.
 - When changing a workflow's or action's inputs/outputs, update its README section
@@ -24,7 +27,8 @@ consumed by other repos. `examples/` holds copy-paste caller workflows for consu
 - This repo hosts a Claude Code plugin marketplace (`.claude-plugin/marketplace.json`
   + `plugins/cicd-toolkit/skills/`). When a workflow's inputs, secrets, or the
   integration flow change, check the plugin skills for drift too — they're the
-  guidance consumer repos' agents receive.
+  guidance consumer repos' agents receive. Bump the version in
+  `plugins/cicd-toolkit/.claude-plugin/plugin.json` whenever skills change.
 - `claude-review.yml` is a **reusable** (`workflow_call`) Claude review workflow
   consumers call like any other; `claude-review-self.yml` dogfoods it on this repo's
   own PRs (inline + sticky comments; skips bot PRs; needs the `CLAUDE_CODE_OAUTH_TOKEN`

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The workflow compares commits between the current and previous semver tags, send
 
 ### End-User What's-New Summaries
 
-Releases are **two-tier**: the GitHub Release body stays engineer-focused and specific, while `release.yml` additionally generates a plain-language, end-user-facing summary your app can display — a `whats-new.json` (latest) and cumulative `releases.json` (last 20) attached to each release as assets.
+Releases are **two-tier**: the GitHub Release body stays engineer-focused and specific, while `release.yml` additionally generates a plain-language, end-user-facing summary your app can display — a `whats-new.json` (latest) and cumulative `releases.json` (last 20) attached to each release as assets. The artifact contract is versioned (`schemaVersion: 1`) and published at [`schemas/whats-new.schema.json`](schemas/whats-new.schema.json).
 
 **How it stays app-aware and leak-free:**
 
@@ -306,6 +306,19 @@ gh secret set AWS_DEPLOY_ROLE_ARN --repo <owner>/<repo>
 ```
 
 Generate your Anthropic API key at [console.anthropic.com](https://console.anthropic.com/) under API Keys. For `claude-review.yml`, also install the [Claude GitHub App](https://github.com/apps/claude) on the repo; Claude Pro/Max subscribers can set `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) instead of an API key to draw on subscription usage rather than per-token billing.
+
+### Pinning & Versions
+
+All examples reference `@main` (bleeding edge — merges here ship to you immediately). Floating release tags are also maintained automatically on every release, so pick your stability tier:
+
+| Ref | Behavior |
+|-----|----------|
+| `@main` | Latest, updates on every merge |
+| `@v2` | Latest release in major 2 — advances on each release, breaking changes gated on `v3` |
+| `@v2.5` | Latest patch of 2.5 |
+| `@<sha>` | Fully pinned (maximum supply-chain rigor) |
+
+Internally, this repo pins third-party actions to commit SHAs (OpenSSF practice); Dependabot keeps the pins current.
 
 ### OIDC Bootstrap (CDK Deploy)
 

--- a/actions/turbo-setup/action.yml
+++ b/actions/turbo-setup/action.yml
@@ -39,7 +39,7 @@ runs:
         key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
     - name: Turbo remote cache
-      uses: rharkor/caching-for-turbo@v2.5.0
+      uses: rharkor/caching-for-turbo@75f8ebf4a43d2c60b23bc2a27082cfea94ffdad9 # v2.5.0
 
     - name: Pre-build workspace packages
       if: inputs.pre-build-filter != ''

--- a/lib/whats-new/index.ts
+++ b/lib/whats-new/index.ts
@@ -7,6 +7,11 @@
  */
 
 export interface WhatsNewRelease {
+  /**
+   * Contract version of the artifact (see schemas/whats-new.schema.json).
+   * Absent on artifacts produced before the field existed — treat as 1.
+   */
+  schemaVersion?: number;
   /** Semver without the leading v, e.g. "1.4.0". */
   version: string;
   /** ISO date (YYYY-MM-DD) the release was published. */
@@ -54,6 +59,7 @@ export function parseWhatsNew(data: unknown): WhatsNewRelease | null {
     return null;
   }
   return {
+    schemaVersion: typeof d.schemaVersion === 'number' ? d.schemaVersion : 1,
     version: d.version,
     date: d.date,
     title: d.title,

--- a/plugins/cicd-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cicd-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cicd-toolkit",
-  "version": "0.1.0",
-  "description": "Integrate KotaHusky/cicd-toolkit reusable GitHub Actions workflows, composite actions, and AWS CDK constructs into a consumer repo — workflow selection, secrets setup, and OIDC bootstrap.",
+  "version": "0.2.0",
+  "description": "Integrate KotaHusky/cicd-toolkit reusable GitHub Actions workflows, composite actions, and AWS CDK constructs into a consumer repo \u2014 workflow selection, secrets setup, and OIDC bootstrap.",
   "author": {
     "name": "KotaHusky"
   }

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -27,7 +27,7 @@ Adapt the example rather than authoring a caller from scratch.
 
 | Consumer need | Workflow |
 |---|---|
-| PR build/test/lint for Node (Turborepo-aware) | `build-verify.yml` |
+| PR build/test/lint for Node (Turborepo-aware) | `build-verify.yml` — also runs an advisory Claude review on PRs when the caller passes `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (opt out with `claude-review: false`; caller job needs `pull-requests: write` for comments) |
 | Enforce Conventional Commits on PRs | `commitlint.yml` |
 | Build + push Docker image to GHCR | `docker-ghcr.yml` |
 | Deploy AWS CDK app (OIDC auth) | `cdk-deploy.yml` (synth-only check: `cdk-synth.yml`) |

--- a/schemas/whats-new.schema.json
+++ b/schemas/whats-new.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/KotaHusky/cicd-toolkit/main/schemas/whats-new.schema.json",
+  "title": "What's-New Release Summary",
+  "description": "End-user-facing release summary produced by release.yml (whats-new.json). The cumulative releases.json is an array of this object, newest first.",
+  "type": "object",
+  "required": ["version", "date", "title", "summary", "highlights"],
+  "additionalProperties": true,
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "description": "Contract version of this artifact. Absent on artifacts produced before v1; consumers should treat absent as 1.",
+      "const": 1
+    },
+    "version": {
+      "type": "string",
+      "description": "App semver without the leading v, e.g. \"1.4.0\"."
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "UTC publish date, YYYY-MM-DD."
+    },
+    "title": {
+      "type": "string",
+      "description": "Short plain-language headline (3-6 words)."
+    },
+    "summary": {
+      "type": "string",
+      "description": "1-2 sentence plain-language overview."
+    },
+    "highlights": {
+      "type": "array",
+      "items": { "type": "string" },
+      "maxItems": 5,
+      "description": "Short user-facing bullets."
+    }
+  }
+}

--- a/test/whats-new.test.ts
+++ b/test/whats-new.test.ts
@@ -28,8 +28,12 @@ function failingFetch(): FetchLike {
 }
 
 describe('parseWhatsNew', () => {
-  it('accepts a valid release', () => {
-    expect(parseWhatsNew(valid)).toEqual(valid);
+  it('accepts a valid release, defaulting schemaVersion to 1', () => {
+    expect(parseWhatsNew(valid)).toEqual({ ...valid, schemaVersion: 1 });
+  });
+
+  it('preserves an explicit schemaVersion', () => {
+    expect(parseWhatsNew({ ...valid, schemaVersion: 1 })?.schemaVersion).toBe(1);
   });
 
   it('rejects missing fields', () => {


### PR DESCRIPTION
## Summary
Implements the community-standards hardening batch:

1. **SHA-pinned third-party actions** (OpenSSF Pinned-Dependencies): every non-GitHub, non-Anthropic action across 11 files now pins a full commit SHA with a `# <tag>` comment. Dependabot's existing actions group keeps pins fresh. Policy documented in CLAUDE.md.
2. **Build provenance** on `docker-ghcr.yml`: new `provenance` input (default `mode=max`) passes BuildKit SLSA-aligned attestations through — no new caller permissions.
3. **harden-runner egress audit** on the secret-handling jobs (`release`, `whats-new`, `claude-review`) — audit mode only, establishes an egress baseline without enforcement risk.
4. **Versioned what's-new contract**: `schemaVersion: 1` in the artifact, published JSON Schema at `schemas/whats-new.schema.json`, lib parses tolerantly (absent → 1) + tests.
5. **Weekly OpenSSF Scorecard** workflow with SARIF upload to code scanning — continuous grading against these standards.
6. **Pinning docs**: README now documents the stability tiers (`@main` / `@v2` / `@v2.5` / `@<sha>`) — the floating tags were already maintained by `self-release.yml`.
7. **Housekeeping**: `self-release.yml` passes the OAuth token (preferred by release.yml since #63); plugin bumped to 0.2.0; skill drift from #62 fixed (embedded review documented in the workflow table).

A branch ruleset on `main` (require PR + Actionlint/ShellCheck/Vitest) is being applied via API alongside this PR.

## Test plan
- [x] 52/52 tests, `tsc --noEmit` clean, all YAML/JSON parses
- [ ] After merge: confirm Scorecard run appears in Security tab; confirm Dependabot next cycle updates SHA pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)