### PR TITLE
feat(review): review-thread resolution gate as reusable-workflow config

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -255,9 +255,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! THREADS=$(gh api graphql \
-              -F owner="${{ github.repository_owner }}" \
-              -F repo="${{ github.event.repository.name }}" \
+          set +e
+          THREADS=$(gh api graphql \
+              -f owner="${{ github.repository_owner }}" \
+              -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
               -f query='query($owner: String!, $repo: String!, $pr: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -265,9 +266,20 @@ jobs:
                     reviewThreads(first: 100) { nodes { isResolved } }
                   }
                 }
-              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length'); then
-            echo "::notice title=Review threads::Could not query review threads (token likely lacks pull-requests read) — skipping the gate."
-            exit 0
+              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -ne 0 ]; then
+            # Fail open ONLY on permission errors (restricted token); fail
+            # closed on anything else (5xx, rate limit) so a consumer who
+            # requires this check never gets false assurance — re-run fixes
+            # transient failures.
+            if echo "$THREADS" | grep -qiE 'resource not accessible|forbidden|permission'; then
+              echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate."
+              exit 0
+            fi
+            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${THREADS}"
+            exit 1
           fi
           if [ "$THREADS" -gt 0 ]; then
             echo "::error title=Unresolved review threads::${THREADS} review thread(s) are unresolved on this PR. Disposition each — push a fix, or reply explaining why it's dismissed — then resolve it and re-run this check (Re-run failed jobs re-runs only this gate, not the review)."

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -35,6 +35,14 @@ on:
         required: false
         type: boolean
         default: true
+      require-resolved-review-threads:
+        description: >-
+          Add a status check that fails while the PR has unresolved review
+          threads, forcing findings to be dispositioned before merge.
+          Advisory unless the caller marks the check required.
+        required: false
+        type: boolean
+        default: true
       claude-review-prompt:
         description: 'Extra project-specific review instructions appended to the default review prompt'
         required: false
@@ -228,3 +236,41 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
             --max-turns 25
+
+  review-threads:
+    # See claude-review.yml's twin job: dispositions review findings before
+    # merge. Ordered after the embedded review so its threads are counted;
+    # "Re-run failed jobs" re-runs only this gate after resolving.
+    name: Review Threads Resolved
+    needs: claude-review
+    if: >-
+      ${{ always() && inputs.require-resolved-review-threads &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check for unresolved review threads
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! THREADS=$(gh api graphql \
+              -F owner="${{ github.repository_owner }}" \
+              -F repo="${{ github.event.repository.name }}" \
+              -F pr="${{ github.event.pull_request.number }}" \
+              -f query='query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    reviewThreads(first: 100) { nodes { isResolved } }
+                  }
+                }
+              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length'); then
+            echo "::notice title=Review threads::Could not query review threads (token likely lacks pull-requests read) — skipping the gate."
+            exit 0
+          fi
+          if [ "$THREADS" -gt 0 ]; then
+            echo "::error title=Unresolved review threads::${THREADS} review thread(s) are unresolved on this PR. Disposition each — push a fix, or reply explaining why it's dismissed — then resolve it and re-run this check (Re-run failed jobs re-runs only this gate, not the review)."
+            exit 1
+          fi
+          echo "All review threads resolved (or none exist)."

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -203,7 +203,7 @@ jobs:
             echo "has-credentials=true" >> "$GITHUB_OUTPUT"
           else
             echo "has-credentials=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Claude review skipped::No ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN secret reached build-verify. Pass one via 'secrets:' (or use 'secrets: inherit') to enable AI review, or set 'claude-review: false' to silence this notice."
+            echo "::notice title=Claude review skipped::No ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN secret reached build-verify. Pass one via 'secrets:' (or 'secrets: inherit') to enable AI review, or set 'claude-review: false' to silence this notice. Note: PRs from forks never receive secrets, so this is expected there."
           fi
 
       - name: Checkout code

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -256,17 +256,22 @@ jobs:
         run: |
           set -euo pipefail
           set +e
-          THREADS=$(gh api graphql \
+          # --paginate + --slurp walks all pages, so >100 threads can't
+          # silently false-pass the gate.
+          THREADS=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
-              -f query='query($owner: String!, $repo: String!, $pr: Int!) {
+              -f query='query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $pr) {
-                    reviewThreads(first: 100) { nodes { isResolved } }
+                    reviewThreads(first: 100, after: $endCursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes { isResolved }
+                    }
                   }
                 }
-              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+              }' --jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
           STATUS=$?
           set -e
           if [ "$STATUS" -ne 0 ]; then
@@ -275,7 +280,7 @@ jobs:
             # requires this check never gets false assurance — re-run fixes
             # transient failures.
             if echo "$THREADS" | grep -qiE 'resource not accessible|forbidden|permission'; then
-              echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate."
+              echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate. Grant the calling job pull-requests: read (or write) to enable it."
               exit 0
             fi
             echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${THREADS}"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -161,17 +161,22 @@ jobs:
         run: |
           set -euo pipefail
           set +e
-          THREADS=$(gh api graphql \
+          # --paginate + --slurp walks all pages, so >100 threads can't
+          # silently false-pass the gate.
+          THREADS=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
-              -f query='query($owner: String!, $repo: String!, $pr: Int!) {
+              -f query='query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $pr) {
-                    reviewThreads(first: 100) { nodes { isResolved } }
+                    reviewThreads(first: 100, after: $endCursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes { isResolved }
+                    }
                   }
                 }
-              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+              }' --jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
           STATUS=$?
           set -e
           if [ "$STATUS" -ne 0 ]; then
@@ -180,7 +185,7 @@ jobs:
             # requires this check never gets false assurance — re-run fixes
             # transient failures.
             if echo "$THREADS" | grep -qiE 'resource not accessible|forbidden|permission'; then
-              echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate."
+              echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate. Grant the calling job pull-requests: read (or write) to enable it."
               exit 0
             fi
             echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${THREADS}"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,6 +25,15 @@ on:
         required: false
         type: string
         default: '25'
+      require-resolved-review-threads:
+        description: >-
+          Add a status check that fails while the PR has unresolved review
+          threads (from Claude or humans), forcing each finding to be
+          dispositioned — fixed or resolved with a reply — before merge.
+          Advisory unless the caller marks the check required.
+        required: false
+        type: boolean
+        default: true
       strict:
         description: >-
           Fail the job when the review cannot run (missing credentials or a
@@ -94,7 +103,7 @@ jobs:
 
       - name: Checkout code
         if: steps.gate.outputs.has-credentials == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -131,3 +140,41 @@ jobs:
         if: steps.gate.outputs.has-credentials == 'true' && steps.review.outcome == 'failure'
         run: |
           echo "::notice title=Claude code review did not complete::The review step failed — see its logs above. The job still passes because strict mode is off; set 'strict: true' to fail the job instead."
+
+  review-threads:
+    # Fails while unresolved review threads exist, so findings must be
+    # dispositioned (fixed, or resolved with a reply saying why) before
+    # merge. Runs after the review so freshly posted threads are counted.
+    # After resolving, use "Re-run failed jobs" — only this gate re-runs.
+    name: Review Threads Resolved
+    needs: review
+    if: >-
+      ${{ always() && inputs.require-resolved-review-threads &&
+          github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check for unresolved review threads
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! THREADS=$(gh api graphql \
+              -F owner="${{ github.repository_owner }}" \
+              -F repo="${{ github.event.repository.name }}" \
+              -F pr="${{ github.event.pull_request.number }}" \
+              -f query='query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    reviewThreads(first: 100) { nodes { isResolved } }
+                  }
+                }
+              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length'); then
+            echo "::notice title=Review threads::Could not query review threads (token likely lacks pull-requests read) — skipping the gate."
+            exit 0
+          fi
+          if [ "$THREADS" -gt 0 ]; then
+            echo "::error title=Unresolved review threads::${THREADS} review thread(s) are unresolved on this PR. Disposition each — push a fix, or reply explaining why it's dismissed — then resolve it and re-run this check (Re-run failed jobs re-runs only this gate, not the review)."
+            exit 1
+          fi
+          echo "All review threads resolved (or none exist)."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -150,7 +150,8 @@ jobs:
     needs: review
     if: >-
       ${{ always() && inputs.require-resolved-review-threads &&
-          github.event_name == 'pull_request' }}
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.type != 'Bot' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -159,9 +160,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! THREADS=$(gh api graphql \
-              -F owner="${{ github.repository_owner }}" \
-              -F repo="${{ github.event.repository.name }}" \
+          set +e
+          THREADS=$(gh api graphql \
+              -f owner="${{ github.repository_owner }}" \
+              -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
               -f query='query($owner: String!, $repo: String!, $pr: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -169,9 +171,20 @@ jobs:
                     reviewThreads(first: 100) { nodes { isResolved } }
                   }
                 }
-              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length'); then
-            echo "::notice title=Review threads::Could not query review threads (token likely lacks pull-requests read) — skipping the gate."
-            exit 0
+              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -ne 0 ]; then
+            # Fail open ONLY on permission errors (restricted token); fail
+            # closed on anything else (5xx, rate limit) so a consumer who
+            # requires this check never gets false assurance — re-run fixes
+            # transient failures.
+            if echo "$THREADS" | grep -qiE 'resource not accessible|forbidden|permission'; then
+              echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate."
+              exit 0
+            fi
+            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${THREADS}"
+            exit 1
           fi
           if [ "$THREADS" -gt 0 ]; then
             echo "::error title=Unresolved review threads::${THREADS} review thread(s) are unresolved on this PR. Disposition each — push a fix, or reply explaining why it's dismissed — then resolve it and re-run this check (Re-run failed jobs re-runs only this gate, not the review)."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,6 @@ consumed by other repos. `examples/` holds copy-paste caller workflows for consu
 - Before starting, check `git worktree list` for conflicts
 - Use conventional commit messages, scoped to the workflow/action/construct touched (e.g. `fix(static-s3-deploy): ...`)
 - After completing work, create a PR — do not merge directly
+- Before merging any PR, disposition every review thread: push a fix, or
+  resolve it with a reply stating why it's dismissed. Never resolve a thread
+  without a reply. The "Review Threads Resolved" check enforces this.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
 | `package-manager` | string | `npm` | Package manager (`npm` or `pnpm`) |
 | `claude-review` | boolean | `true` | Advisory Claude AI review on PRs; activates only when an Anthropic secret is passed |
 | `claude-review-prompt` | string | `''` | Extra project-specific review instructions |
-| `require-resolved-review-threads` | boolean | `true` | Status check that fails while the PR has unresolved review threads — findings must be fixed or resolved-with-a-reply before merge |
+| `require-resolved-review-threads` | boolean | `true` | Status check that fails while the PR has unresolved review threads — findings must be fixed or resolved-with-a-reply before merge. Needs `pull-requests: read` on the caller (no-ops with a notice otherwise). Don't mark it a *required* branch check unless every PR runs it: skipped paths (bot PRs, `push` events, opt-out) leave a required check stuck on "Expected" |
 
 **Built-in Claude review:** when the caller passes `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (directly or via `secrets: inherit`), pull requests get an advisory AI review (inline comments + sticky summary) with no extra workflow file. It never blocks CI: no credentials → skip with a notice; insufficient permissions → the review step is swallowed. For comments to post, grant the calling job `pull-requests: write` (see [Claude Code Review](#claude-code-review) for the standalone workflow and full permission block). Requires the [Claude GitHub App](https://github.com/apps/claude) on the repo. Set `claude-review: false` to opt out.
 
@@ -284,7 +284,7 @@ To source the key from a GitHub environment in the consuming repo instead of a r
 | `review-prompt` | string | `''` | Extra project-specific review instructions |
 | `max-turns` | string | `25` | Max agent turns per review (cost control) |
 | `strict` | boolean | `false` | Fail the job when the review can't run (missing credentials or a review error); default is a notice annotation and a passing job |
-| `require-resolved-review-threads` | boolean | `true` | Status check ("Review Threads Resolved") that fails while the PR has unresolved review threads — disposition each finding (fix, or resolve with a reply saying why) then re-run the failed gate job |
+| `require-resolved-review-threads` | boolean | `true` | Status check ("Review Threads Resolved") that fails while the PR has unresolved review threads — disposition each finding (fix, or resolve with a reply saying why) then re-run the failed gate job. Needs `pull-requests: read`; skips bot PRs. Don't mark it a *required* branch check unless every PR runs it — skipped paths leave a required check stuck on "Expected" |
 
 | Secret | Required | Description |
 |--------|----------|-------------|

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
 | `package-manager` | string | `npm` | Package manager (`npm` or `pnpm`) |
 | `claude-review` | boolean | `true` | Advisory Claude AI review on PRs; activates only when an Anthropic secret is passed |
 | `claude-review-prompt` | string | `''` | Extra project-specific review instructions |
+| `require-resolved-review-threads` | boolean | `true` | Status check that fails while the PR has unresolved review threads — findings must be fixed or resolved-with-a-reply before merge |
 
 **Built-in Claude review:** when the caller passes `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (directly or via `secrets: inherit`), pull requests get an advisory AI review (inline comments + sticky summary) with no extra workflow file. It never blocks CI: no credentials → skip with a notice; insufficient permissions → the review step is swallowed. For comments to post, grant the calling job `pull-requests: write` (see [Claude Code Review](#claude-code-review) for the standalone workflow and full permission block). Requires the [Claude GitHub App](https://github.com/apps/claude) on the repo. Set `claude-review: false` to opt out.
 
@@ -283,6 +284,7 @@ To source the key from a GitHub environment in the consuming repo instead of a r
 | `review-prompt` | string | `''` | Extra project-specific review instructions |
 | `max-turns` | string | `25` | Max agent turns per review (cost control) |
 | `strict` | boolean | `false` | Fail the job when the review can't run (missing credentials or a review error); default is a notice annotation and a passing job |
+| `require-resolved-review-threads` | boolean | `true` | Status check ("Review Threads Resolved") that fails while the PR has unresolved review threads — disposition each finding (fix, or resolve with a reply saying why) then re-run the failed gate job |
 
 | Secret | Required | Description |
 |--------|----------|-------------|

--- a/plugins/cicd-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cicd-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cicd-toolkit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Integrate KotaHusky/cicd-toolkit reusable GitHub Actions workflows, composite actions, and AWS CDK constructs into a consumer repo \u2014 workflow selection, secrets setup, and OIDC bootstrap.",
   "author": {
     "name": "KotaHusky"

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -108,6 +108,15 @@ pbpaste | gh secret set ANTHROPIC_API_KEY -R <owner>/<repo>
 Verify either with `gh secret list -R <owner>/<repo>` — names and timestamps only;
 values are never readable back, which is the point.
 
+## Review-thread discipline
+
+Both review surfaces add a "Review Threads Resolved" status check (input
+`require-resolved-review-threads`, default true): it fails while the PR has
+unresolved review threads. When helping in a consumer repo, disposition each
+finding — push a fix, or resolve the thread with a reply saying why it's
+dismissed — then re-run the failed gate job only. Never resolve without a
+reply.
+
 ## What's-New summaries (end-user release notes)
 
 `release.yml` produces two tiers on every `v*` tag: engineer-focused notes (the


### PR DESCRIPTION
## Summary
Per discussion: forced review should force *disposition* of findings — and that gate belongs in the reusable workflows, not per-repo GitHub settings.

- New **`Review Threads Resolved`** job in `claude-review.yml` and the embedded path in `build-verify.yml`, behind `require-resolved-review-threads` (default `true`): queries unresolved review threads via GraphQL and fails while any exist. Findings must be fixed or resolved-with-a-reply before merge.
- Ordered `needs: review` so freshly posted threads are counted; after resolving, "Re-run failed jobs" re-runs only the gate (not the review, so no duplicate comments/spend).
- Degrades gracefully: skips with a notice when the token can't read threads; bot PRs excluded on the build-verify path.
- Deliberately **not** added to this repo's required checks: the review workflow skips bot PRs, so a required check from it would hang dependabot merges on "Expected".
- CLAUDE.md merge discipline: disposition every thread, never resolve without a reply. Skill teaches the same to consumer agents. Plugin → 0.3.0.

## Test plan
- [x] YAML parses; gate scripts `bash -n` clean; 52/52 tests
- [ ] After merge: leave a test thread unresolved on a PR and confirm the gate goes red, then resolve + re-run failed jobs → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)