### PR TITLE
fix(whats-new): second-review findings — word-boundary deny-list, version-matched baking, dead code

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -125,10 +125,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$(dirname "${TARGET}")"
-          if gh release download --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber 2>/dev/null; then
-            echo "Injected what's-new summary at ${TARGET}"
+          # Prefer the summary of the exact version being built (when the
+          # version input is set) so rollbacks/redeploys of older refs don't
+          # bake a newer release's summary; fall back to the latest release.
+          if [ -n "${{ inputs.version }}" ] && gh release download "v${{ inputs.version }}" --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber 2>/dev/null; then
+            echo "Injected what's-new summary for v${{ inputs.version }} at ${TARGET}"
+          elif gh release download --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber 2>/dev/null; then
+            echo "Injected what's-new summary (latest release) at ${TARGET}"
           else
-            echo "::notice title=whats-new::No whats-new.json asset on the latest release — skipping injection. The app should handle the file being absent."
+            echo "::notice title=whats-new::No whats-new.json asset found (note: drafts/prereleases are not considered) — skipping injection. The app should handle the file being absent."
           fi
 
       - name: Build and push

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -46,10 +46,11 @@ on:
         default: 'mode=max'
       whats-new-path:
         description: >-
-          Bake the latest release's whats-new.json into the build context at
-          this path (relative to repo root, e.g. public/whats-new.json) before
-          the image is built. Empty disables. See the What's-New section of
-          the README.
+          Bake a whats-new.json into the build context at this path (relative
+          to repo root, e.g. public/whats-new.json) before the image is built.
+          Prefers the release matching the version input; falls back to the
+          latest release. Empty disables. See the What's-New section of the
+          README.
         required: false
         type: string
         default: ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,6 @@ jobs:
     timeout-minutes: 10
     outputs:
       release-url: ${{ steps.create-release.outputs.release-url }}
-      previous-tag: ${{ steps.changelog.outputs.previous-tag }}
     steps:
       - name: Harden runner (egress audit)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
@@ -100,7 +99,6 @@ jobs:
 
           # Find the previous semver tag (skip the current one)
           PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -n 1 || true)
-          echo "previous-tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
 
           if [ -n "$PREVIOUS_TAG" ]; then
             echo "Previous tag: ${PREVIOUS_TAG}"
@@ -450,7 +448,9 @@ jobs:
 
           printf '%s\n' "secret" "token" "api key" "apikey" "password" "credential" > /tmp/denylist.txt
           cat /tmp/denylist-custom.txt >> /tmp/denylist.txt
-          VIOLATIONS=$(grep -i -F -f /tmp/denylist.txt "$BODY_FILE" || true)
+          # -w: whole-word matching, so short terms (e.g. "AWS") don't
+          # false-positive on substrings ("draws", "flaws").
+          VIOLATIONS=$(grep -i -w -F -f /tmp/denylist.txt "$BODY_FILE" || true)
           if [ -n "$VIOLATIONS" ]; then
             echo "::error title=whats-new::Deny-listed term found in the public summary — not publishing. Matches:"
             echo "$VIOLATIONS" >&2
@@ -466,7 +466,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ github.ref_name }}"
-          PREV_TAG="${{ needs.release.outputs.previous-tag }}"
 
           if [ "${{ inputs.auto-publish }}" != "true" ]; then
             cp /tmp/whats-new.json /tmp/whats-new.draft.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,7 +446,10 @@ jobs:
           fi
           jq -e '.title and .summary and (.highlights | type == "array")' "$BODY_FILE" > /dev/null             || { echo "::error title=whats-new::Generated summary is not valid JSON with title/summary/highlights"; cat "$BODY_FILE" >&2; exit 1; }
 
-          printf '%s\n' "secret" "token" "api key" "apikey" "password" "credential" > /tmp/denylist.txt
+          printf '%s\n' \
+            "secret" "secrets" "token" "tokens" "api key" "api keys" \
+            "apikey" "apikeys" "password" "passwords" "credential" "credentials" \
+            > /tmp/denylist.txt
           cat /tmp/denylist-custom.txt >> /tmp/denylist.txt
           # -w: whole-word matching, so short terms (e.g. "AWS") don't
           # false-positive on substrings ("draws", "flaws").

--- a/.github/workflows/static-s3-deploy.yml
+++ b/.github/workflows/static-s3-deploy.yml
@@ -147,7 +147,7 @@ jobs:
           if gh release download --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber 2>/dev/null; then
             echo "Injected what's-new summary at ${TARGET}"
           else
-            echo "::notice title=whats-new::No whats-new.json asset on the latest release — skipping injection. The app should handle the file being absent."
+            echo "::notice title=whats-new::No whats-new.json asset found (note: drafts/prereleases are not considered; this step always bakes the latest release's summary) — skipping injection. The app should handle the file being absent."
           fi
 
       - name: Build

--- a/examples/whats-new-context.md
+++ b/examples/whats-new-context.md
@@ -36,10 +36,11 @@ use these words.>
 
 <!--
   One term per line. Publishing FAILS (mechanically, case-insensitive
-  substring match) if any of these appear in the public summary. Add your
+  WHOLE-WORD match) if any of these appear in the public summary. Add your
   internal service names, cloud providers, and anything else that must
-  never leak. A few defaults (secret, token, api key, password, credential)
-  are always enforced by the workflow.
+  never leak. Prefer specific terms — very generic words will block
+  legitimate summaries. A few defaults (secret, token, api key, password,
+  credential) are always enforced by the workflow.
 -->
 
 - internal


### PR DESCRIPTION
Addresses the three findings from the re-review on #63:
- **Word-boundary deny-list** (`grep -i -w -F`): short terms like `AWS` no longer false-positive on "draws"/"flaws"; example context file documents whole-word semantics and recommends specific terms.
- **Version-matched baking** in `docker-ghcr.yml`: when `version` is set, download `whats-new.json` from that exact release first (latest as fallback) — rollbacks/redeploys of older refs no longer bake a newer release's summary. `static-s3-deploy` notice documents its latest-release semantics and the drafts/prereleases exclusion.
- **Dead code**: removed unused `PREV_TAG` / `previous-tag` output left behind by the history-fallback refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)