### PR TITLE
fix(whats-new): underscore-aware deny gate; version-strict baking

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -126,12 +126,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$(dirname "${TARGET}")"
-          # Prefer the summary of the exact version being built (when the
-          # version input is set) so rollbacks/redeploys of older refs don't
-          # bake a newer release's summary; fall back to the latest release.
-          if [ -n "${{ inputs.version }}" ] && gh release download "v${{ inputs.version }}" --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber 2>/dev/null; then
-            echo "Injected what's-new summary for v${{ inputs.version }} at ${TARGET}"
-          elif gh release download --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber 2>/dev/null; then
+          # When a version is being built, bake ONLY that version's summary —
+          # never fall back to latest, which would give an older ref a newer
+          # release's notes (the rollback case). Latest is used only for
+          # unversioned builds.
+          if [ -n "${{ inputs.version }}" ]; then
+            if gh release download "v${{ inputs.version }}" --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber; then
+              echo "Injected what's-new summary for v${{ inputs.version }} at ${TARGET}"
+            else
+              echo "::notice title=whats-new::No whats-new.json for v${{ inputs.version }} (release missing, or cut before this feature) — skipping injection rather than baking a mismatched summary."
+            fi
+          elif gh release download --repo "${{ github.repository }}" --pattern 'whats-new.json' --output "${TARGET}" --clobber; then
             echo "Injected what's-new summary (latest release) at ${TARGET}"
           else
             echo "::notice title=whats-new::No whats-new.json asset found (note: drafts/prereleases are not considered) — skipping injection. The app should handle the file being absent."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,8 +452,10 @@ jobs:
             > /tmp/denylist.txt
           cat /tmp/denylist-custom.txt >> /tmp/denylist.txt
           # -w: whole-word matching, so short terms (e.g. "AWS") don't
-          # false-positive on substrings ("draws", "flaws").
-          VIOLATIONS=$(grep -i -w -F -f /tmp/denylist.txt "$BODY_FILE" || true)
+          # false-positive on substrings ("draws", "flaws"). Underscores are
+          # word-constituents to grep, so also scan a copy with _ -> space:
+          # client_secret / api_key / ACCESS_TOKEN still hit the gate.
+          VIOLATIONS=$({ cat "$BODY_FILE"; tr '_' ' ' < "$BODY_FILE"; } | grep -i -w -F -f /tmp/denylist.txt || true)
           if [ -n "$VIOLATIONS" ]; then
             echo "::error title=whats-new::Deny-listed term found in the public summary — not publishing. Matches:"
             echo "$VIOLATIONS" >&2


### PR DESCRIPTION
Post-merge follow-ups from the re-review on #67:
- Deny gate scans an underscore-normalized copy of the summary alongside the raw text, so `client_secret` / `api_key` / `ACCESS_TOKEN` shapes still match under whole-word semantics.
- `docker-ghcr` versioned builds never fall back to the latest release's summary (the rollback-mismatch case) — they bake their own version's asset or skip with a notice; stderr no longer suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)