### PR TITLE
fix(build-verify): gh api no longer allows --slurp with --jq — parse with standalone jq

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -257,8 +257,9 @@ jobs:
           set -euo pipefail
           set +e
           # --paginate + --slurp walks all pages, so >100 threads can't
-          # silently false-pass the gate.
-          THREADS=$(gh api graphql --paginate --slurp \
+          # silently false-pass the gate. gh rejects --slurp combined with
+          # --jq, so the response is parsed with standalone jq below.
+          RAW=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
@@ -271,8 +272,13 @@ jobs:
                     }
                   }
                 }
-              }' --jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+              }' 2>&1)
           STATUS=$?
+          if [ "$STATUS" -eq 0 ]; then
+            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+            STATUS=$?
+          fi
+          THREADS=${THREADS:-$RAW}
           set -e
           if [ "$STATUS" -ne 0 ]; then
             # Fail open ONLY on permission errors (restricted token); fail

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -162,8 +162,9 @@ jobs:
           set -euo pipefail
           set +e
           # --paginate + --slurp walks all pages, so >100 threads can't
-          # silently false-pass the gate.
-          THREADS=$(gh api graphql --paginate --slurp \
+          # silently false-pass the gate. gh rejects --slurp combined with
+          # --jq, so the response is parsed with standalone jq below.
+          RAW=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
@@ -176,8 +177,13 @@ jobs:
                     }
                   }
                 }
-              }' --jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+              }' 2>&1)
           STATUS=$?
+          if [ "$STATUS" -eq 0 ]; then
+            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+            STATUS=$?
+          fi
+          THREADS=${THREADS:-$RAW}
           set -e
           if [ "$STATUS" -ne 0 ]; then
             # Fail open ONLY on permission errors (restricted token); fail


### PR DESCRIPTION
Newer gh CLI on hosted runners rejects `--slurp` combined with `--jq`, which makes the **Review Threads Resolved** gate fail on every consumer PR (e.g. KotaHusky/den#308) with:

> the `--slurp` option is not supported with `--jq` or `--template`

Fix: keep `--paginate --slurp` (so >100 threads still can't false-pass) and parse the response with standalone `jq`, which is preinstalled on all hosted runners. Error-path semantics unchanged — permission errors still fail open, everything else fails closed with the raw output in the error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)