### PR TITLE
fix(build-verify): review-threads gate broken by gh --slurp/--jq conflict

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -257,8 +257,9 @@ jobs:
           set -euo pipefail
           set +e
           # --paginate + --slurp walks all pages, so >100 threads can't
-          # silently false-pass the gate.
-          THREADS=$(gh api graphql --paginate --slurp \
+          # silently false-pass the gate. gh rejects --slurp combined with
+          # --jq, so the count is extracted with a standalone jq pass below.
+          RAW=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
@@ -271,7 +272,7 @@ jobs:
                     }
                   }
                 }
-              }' --jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+              }' 2>&1)
           STATUS=$?
           set -e
           if [ "$STATUS" -ne 0 ]; then
@@ -279,13 +280,14 @@ jobs:
             # closed on anything else (5xx, rate limit) so a consumer who
             # requires this check never gets false assurance — re-run fixes
             # transient failures.
-            if echo "$THREADS" | grep -qiE 'resource not accessible|forbidden|permission'; then
+            if echo "$RAW" | grep -qiE 'resource not accessible|forbidden|permission'; then
               echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate. Grant the calling job pull-requests: read (or write) to enable it."
               exit 0
             fi
-            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${THREADS}"
+            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${RAW}"
             exit 1
           fi
+          THREADS=$(echo "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length')
           if [ "$THREADS" -gt 0 ]; then
             echo "::error title=Unresolved review threads::${THREADS} review thread(s) are unresolved on this PR. Disposition each — push a fix, or reply explaining why it's dismissed — then resolve it and re-run this check (Re-run failed jobs re-runs only this gate, not the review)."
             exit 1


### PR DESCRIPTION
## Summary

The "Review Threads Resolved" gate fails on **every** consumer PR — even ones with zero review threads — because current `gh` releases reject combining `--paginate --slurp` with `--jq`:

```
the --slurp option is not supported with --jq or --template
```

Since the command exits non-zero and the error text doesn't match the permission allow-list, the gate fails closed unconditionally (seen on KotaHusky/den#309, run 29312742316).

## Fix

Capture the slurped pages into `RAW` first (keeping the existing fail-open-on-permission / fail-closed-on-transient logic against the raw output), then count unresolved threads with a standalone `jq` pass. Pagination behavior (>100 threads can't false-pass) is unchanged.

The jq expression was validated against a synthetic slurped payload (3 nodes, 2 unresolved → `2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)