### PR TITLE
fix(review): gate stderr captured separately — benign gh warnings can't poison the jq parse

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -257,8 +257,9 @@ jobs:
           set -euo pipefail
           set +e
           # --paginate + --slurp walks all pages, so >100 threads can't
-          # silently false-pass the gate.
-          THREADS=$(gh api graphql --paginate --slurp \
+          # silently false-pass the gate. gh rejects --slurp combined with
+          # --jq, so the response is parsed with standalone jq below.
+          RAW=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
@@ -271,8 +272,13 @@ jobs:
                     }
                   }
                 }
-              }' --jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+              }' 2>&1)
           STATUS=$?
+          if [ "$STATUS" -eq 0 ]; then
+            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+            STATUS=$?
+          fi
+          THREADS=${THREADS:-$RAW}
           set -e
           if [ "$STATUS" -ne 0 ]; then
             # Fail open ONLY on permission errors (restricted token); fail

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -259,6 +259,8 @@ jobs:
           # --paginate + --slurp walks all pages, so >100 threads can't
           # silently false-pass the gate. gh rejects --slurp combined with
           # --jq, so the response is parsed with standalone jq below.
+          # stderr is captured separately so a benign warning from a
+          # successful call can't poison the jq parse and fail the gate.
           RAW=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
@@ -272,24 +274,25 @@ jobs:
                     }
                   }
                 }
-              }' 2>&1)
+              }' 2>/tmp/threads-err.txt)
           STATUS=$?
           if [ "$STATUS" -eq 0 ]; then
-            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>>/tmp/threads-err.txt)
             STATUS=$?
           fi
-          THREADS=${THREADS:-$RAW}
           set -e
           if [ "$STATUS" -ne 0 ]; then
+            ERR=$(cat /tmp/threads-err.txt 2>/dev/null || true)
             # Fail open ONLY on permission errors (restricted token); fail
             # closed on anything else (5xx, rate limit) so a consumer who
             # requires this check never gets false assurance — re-run fixes
-            # transient failures.
-            if echo "$THREADS" | grep -qiE 'resource not accessible|forbidden|permission'; then
+            # transient failures. GraphQL-level errors can land on either
+            # stream, so both are checked.
+            if printf '%s\n%s' "$ERR" "$RAW" | grep -qiE 'resource not accessible|forbidden|permission'; then
               echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate. Grant the calling job pull-requests: read (or write) to enable it."
               exit 0
             fi
-            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${THREADS}"
+            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Error: ${ERR:-$RAW}"
             exit 1
           fi
           if [ "$THREADS" -gt 0 ]; then

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -164,6 +164,8 @@ jobs:
           # --paginate + --slurp walks all pages, so >100 threads can't
           # silently false-pass the gate. gh rejects --slurp combined with
           # --jq, so the response is parsed with standalone jq below.
+          # stderr is captured separately so a benign warning from a
+          # successful call can't poison the jq parse and fail the gate.
           RAW=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
@@ -177,24 +179,25 @@ jobs:
                     }
                   }
                 }
-              }' 2>&1)
+              }' 2>/tmp/threads-err.txt)
           STATUS=$?
           if [ "$STATUS" -eq 0 ]; then
-            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>>/tmp/threads-err.txt)
             STATUS=$?
           fi
-          THREADS=${THREADS:-$RAW}
           set -e
           if [ "$STATUS" -ne 0 ]; then
+            ERR=$(cat /tmp/threads-err.txt 2>/dev/null || true)
             # Fail open ONLY on permission errors (restricted token); fail
             # closed on anything else (5xx, rate limit) so a consumer who
             # requires this check never gets false assurance — re-run fixes
-            # transient failures.
-            if echo "$THREADS" | grep -qiE 'resource not accessible|forbidden|permission'; then
+            # transient failures. GraphQL-level errors can land on either
+            # stream, so both are checked.
+            if printf '%s\n%s' "$ERR" "$RAW" | grep -qiE 'resource not accessible|forbidden|permission'; then
               echo "::notice title=Review threads::Token lacks permission to read review threads — skipping the gate. Grant the calling job pull-requests: read (or write) to enable it."
               exit 0
             fi
-            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Output: ${THREADS}"
+            echo "::error title=Review threads::Could not query review threads (transient error?) — re-run this job. Error: ${ERR:-$RAW}"
             exit 1
           fi
           if [ "$THREADS" -gt 0 ]; then

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -162,8 +162,9 @@ jobs:
           set -euo pipefail
           set +e
           # --paginate + --slurp walks all pages, so >100 threads can't
-          # silently false-pass the gate.
-          THREADS=$(gh api graphql --paginate --slurp \
+          # silently false-pass the gate. gh rejects --slurp combined with
+          # --jq, so the response is parsed with standalone jq below.
+          RAW=$(gh api graphql --paginate --slurp \
               -f owner="${{ github.repository_owner }}" \
               -f repo="${{ github.event.repository.name }}" \
               -F pr="${{ github.event.pull_request.number }}" \
@@ -176,8 +177,13 @@ jobs:
                     }
                   }
                 }
-              }' --jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+              }' 2>&1)
           STATUS=$?
+          if [ "$STATUS" -eq 0 ]; then
+            THREADS=$(printf '%s' "$RAW" | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' 2>&1)
+            STATUS=$?
+          fi
+          THREADS=${THREADS:-$RAW}
           set -e
           if [ "$STATUS" -ne 0 ]; then
             # Fail open ONLY on permission errors (restricted token); fail


### PR DESCRIPTION
## Problem

Found by the Claude review on #72: since the --slurp/--jq fix, the review-threads gate captures `2>&1` into `RAW`. A **successful** `gh` call that emits any stderr (deprecation warning, upgrade notice) gets that text prepended to the JSON, `jq` fails to parse, and — because the warning won't match the permission allow-list — the gate fails **closed** with a spurious "transient error".

## Fix

- stderr goes to `/tmp/threads-err.txt` (jq's stderr appends there too) and is only read on the failure path.
- The permission fail-open grep checks **both** streams, since GraphQL-level errors land in the response body (stdout) while HTTP/CLI errors land on stderr — preserving existing fail-open/fail-closed semantics exactly.
- Applied identically to both gate copies (`build-verify.yml`, `claude-review.yml`).

## Validation

`bash -n` on both extracted step scripts ✅ · `npm test` 52/52 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)