### PR TITLE
feat(auto-version): automatic semver + release on merge to main

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -69,7 +69,9 @@ on:
         description: 'The tag that was created and released (empty when nothing was releasable)'
         value: ${{ jobs.version.outputs.tag }}
       bump:
-        description: 'The computed bump: major, minor, patch, or none'
+        description: >-
+          The computed bump: major, minor, patch, none, or retry (an earlier
+          run tagged but failed to release; this run re-released that tag)
         value: ${{ jobs.version.outputs.bump }}
 
 concurrency:
@@ -104,6 +106,26 @@ jobs:
           LAST=$(gh api --paginate "repos/${REPO}/tags" --jq '.[].name' \
             | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n 1)
 
+          # Self-heal an orphaned tag: if the last tag has no GitHub Release,
+          # a prior release run failed after tagging. Re-release that tag
+          # instead of computing a new bump — otherwise its commits would be
+          # skipped forever (the next compare starts from it). Commits since
+          # the orphan ship in the next releasable merge. Skipped for draft
+          # releases, which the releases/tags endpoint cannot see.
+          if [ -n "$LAST" ] && [ "${{ inputs.draft }}" != "true" ] \
+             && ! gh api "repos/${REPO}/releases/tags/${LAST}" > /dev/null 2>&1; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "bump=retry" >> "$GITHUB_OUTPUT"
+              echo "tag=" >> "$GITHUB_OUTPUT"
+              echo "::notice title=auto-version::Dry run — ${LAST} is tagged but unreleased; a real run would re-release it."
+              exit 0
+            fi
+            echo "bump=retry" >> "$GITHUB_OUTPUT"
+            echo "tag=${LAST}" >> "$GITHUB_OUTPUT"
+            echo "::warning title=auto-version::${LAST} is tagged but has no GitHub Release (a prior release run failed) — re-releasing it. Commits merged since will ship in the next release."
+            exit 0
+          fi
+
           if [ -z "$LAST" ]; then
             BUMP="minor"
             NEW="v${INITIAL}"
@@ -122,8 +144,11 @@ jobs:
               | jq -r '.commits[] | select(.parents | length == 1) | .commit.message | split("\n")[0]')
 
             BUMP="none"
+            # Breaking markers: a bang type (feat!:) in a subject, or a
+            # BREAKING CHANGE / BREAKING-CHANGE footer line — anchored so
+            # prose that merely mentions the phrase can't force a major.
             if printf '%s' "$SUBJECTS" | grep -qE '^[a-z]+(\([^)]*\))?!:' \
-               || printf '%s' "$MESSAGES" | grep -q 'BREAKING CHANGE'; then
+               || printf '%s' "$MESSAGES" | grep -qE '^BREAKING[ -]CHANGE:'; then
               BUMP="major"
             elif printf '%s' "$SUBJECTS" | grep -qE '^feat(\([^)]*\))?:'; then
               BUMP="minor"
@@ -184,23 +209,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Shallow: HEAD is the release commit, which is all the floating tags
-      # need to point at. fetch-tags: true is fatal on tag-push events
+      # Shallow: only the released tag's commit is needed; it is fetched
+      # explicitly below. fetch-tags: true is fatal on tag-push events
       # (actions/checkout#1467) and unnecessary here.
       - uses: actions/checkout@v7
 
       - name: Advance floating tags
         shell: bash
+        env:
+          TAG: ${{ needs.version.outputs.tag }}
         run: |
-          # e.g. v2.5.4 → advance v2 and v2.5 to point at this commit
-          TAG="${{ needs.version.outputs.tag }}"
+          # e.g. v2.5.4 → advance v2 and v2.5 to point at its commit.
+          # Anchored to the tag, not HEAD — on a retry release (orphaned
+          # tag healed by a later push) HEAD is newer than the release.
           if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
             MAJOR="v${BASH_REMATCH[1]}"
             MINOR="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            git fetch --depth=1 origin "refs/tags/${TAG}:refs/tags/${TAG}"
             git config user.name  "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -fa "$MAJOR" -m "Update floating tag $MAJOR → $TAG"
-            git tag -fa "$MINOR" -m "Update floating tag $MINOR → $TAG"
+            git tag -fa "$MAJOR" -m "Update floating tag $MAJOR → $TAG" "$TAG"
+            git tag -fa "$MINOR" -m "Update floating tag $MINOR → $TAG" "$TAG"
             git push origin "$MAJOR" "$MINOR" --force
             echo "Advanced $MAJOR and $MINOR to $TAG"
           else

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -133,43 +133,51 @@ jobs:
             exit 0
           fi
 
+          # Non-merge commit messages in the release range: everything since
+          # the last tag, or (first release) the last 100 commits on the
+          # branch. The compare API returns at most 250 commits; warn rather
+          # than misversion.
           if [ -z "$LAST" ]; then
-            BUMP="minor"
-            NEW="v${INITIAL}"
-            echo "No semver tag found — first release will be ${NEW}."
+            RANGE=$(gh api "repos/${REPO}/commits?sha=${SHA}&per_page=100" \
+              --jq '[.[] | select(.parents | length == 1) | .commit.message]')
           else
-            # Non-merge commit messages since the last tag. The compare API
-            # returns at most 250 commits; warn rather than misversion.
             COMPARE=$(gh api "repos/${REPO}/compare/${LAST}...${SHA}")
             TOTAL=$(echo "$COMPARE" | jq '.total_commits')
             if [ "$TOTAL" -gt 250 ]; then
               echo "::warning title=auto-version::${TOTAL} commits since ${LAST} but only 250 inspected — bump may be understated. Consider tagging manually."
             fi
-            MESSAGES=$(echo "$COMPARE" \
-              | jq -r '.commits[] | select(.parents | length == 1) | .commit.message')
-            SUBJECTS=$(echo "$COMPARE" \
-              | jq -r '.commits[] | select(.parents | length == 1) | .commit.message | split("\n")[0]')
+            RANGE=$(echo "$COMPARE" \
+              | jq '[.commits[] | select(.parents | length == 1) | .commit.message]')
+          fi
+          MESSAGES=$(echo "$RANGE" | jq -r '.[]')
+          SUBJECTS=$(echo "$RANGE" | jq -r '.[] | split("\n")[0]')
 
-            BUMP="none"
-            # Breaking markers: a bang type (feat!:) in a subject, or a
-            # BREAKING CHANGE / BREAKING-CHANGE footer line — anchored so
-            # prose that merely mentions the phrase can't force a major.
-            if printf '%s' "$SUBJECTS" | grep -qE '^[a-z]+(\([^)]*\))?!:' \
-               || printf '%s' "$MESSAGES" | grep -qE '^BREAKING[ -]CHANGE:'; then
-              BUMP="major"
-            elif printf '%s' "$SUBJECTS" | grep -qE '^feat(\([^)]*\))?:'; then
-              BUMP="minor"
-            elif printf '%s' "$SUBJECTS" | grep -qE '^(fix|perf|revert)(\([^)]*\))?:'; then
-              BUMP="patch"
-            fi
+          BUMP="none"
+          # Breaking markers: a bang type (feat!:) in a subject, or a
+          # BREAKING CHANGE / BREAKING-CHANGE footer line — anchored so
+          # prose that merely mentions the phrase can't force a major.
+          if printf '%s' "$SUBJECTS" | grep -qE '^[a-z]+(\([^)]*\))?!:' \
+             || printf '%s' "$MESSAGES" | grep -qE '^BREAKING[ -]CHANGE:'; then
+            BUMP="major"
+          elif printf '%s' "$SUBJECTS" | grep -qE '^feat(\([^)]*\))?:'; then
+            BUMP="minor"
+          elif printf '%s' "$SUBJECTS" | grep -qE '^(fix|perf|revert)(\([^)]*\))?:'; then
+            BUMP="patch"
+          fi
 
-            if [ "$BUMP" = "none" ]; then
-              echo "bump=none" >> "$GITHUB_OUTPUT"
-              echo "tag=" >> "$GITHUB_OUTPUT"
-              echo "::notice title=auto-version::No feat/fix/perf/breaking commits since ${LAST} — nothing to release."
-              exit 0
-            fi
+          if [ "$BUMP" = "none" ]; then
+            echo "bump=none" >> "$GITHUB_OUTPUT"
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "::notice title=auto-version::No feat/fix/perf/breaking commits ${LAST:+since ${LAST} }— nothing to release."
+            exit 0
+          fi
 
+          if [ -z "$LAST" ]; then
+            # First release: bootstrap at initial-version regardless of the
+            # bump size, but only once a releasable commit exists (above).
+            NEW="v${INITIAL}"
+            echo "No semver tag found — first release will be ${NEW} (${BUMP} commit present)."
+          else
             IFS='.' read -r MAJOR MINOR PATCH <<< "${LAST#v}"
             case "$BUMP" in
               major) NEW="v$((MAJOR + 1)).0.0" ;;

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -106,13 +106,20 @@ jobs:
           LAST=$(gh api --paginate "repos/${REPO}/tags" --jq '.[].name' \
             | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n 1)
 
-          # Self-heal an orphaned tag: if the last tag has no GitHub Release,
-          # a prior release run failed after tagging. Re-release that tag
-          # instead of computing a new bump — otherwise its commits would be
-          # skipped forever (the next compare starts from it). Commits since
-          # the orphan ship in the next releasable merge. Skipped for draft
-          # releases, which the releases/tags endpoint cannot see.
-          if [ -n "$LAST" ] && [ "${{ inputs.draft }}" != "true" ] \
+          # Self-heal an orphaned tag: if the last tag has no GitHub Release
+          # but the repo does release, a prior release run failed after
+          # tagging. Re-release that tag instead of computing a new bump —
+          # otherwise its commits would be skipped forever (the next compare
+          # starts from it). Commits since the orphan ship in the next
+          # releasable merge. Guarded on at least one existing Release so a
+          # repo adopting this workflow with plain unreleased git tags gets
+          # a normal bump, not a surprise release of its old tag. Skipped
+          # for draft releases, which the releases endpoints cannot see.
+          HAS_RELEASES=false
+          if gh api "repos/${REPO}/releases/latest" > /dev/null 2>&1; then
+            HAS_RELEASES=true
+          fi
+          if [ -n "$LAST" ] && [ "$HAS_RELEASES" = "true" ] && [ "${{ inputs.draft }}" != "true" ] \
              && ! gh api "repos/${REPO}/releases/tags/${LAST}" > /dev/null 2>&1; then
             if [ "$DRY_RUN" = "true" ]; then
               echo "bump=retry" >> "$GITHUB_OUTPUT"
@@ -122,7 +129,7 @@ jobs:
             fi
             echo "bump=retry" >> "$GITHUB_OUTPUT"
             echo "tag=${LAST}" >> "$GITHUB_OUTPUT"
-            echo "::warning title=auto-version::${LAST} is tagged but has no GitHub Release (a prior release run failed) — re-releasing it. Commits merged since will ship in the next release."
+            echo "::warning title=auto-version::${LAST} is tagged but has no GitHub Release (most likely a prior release run failed after tagging) — re-releasing it. Commits merged since will ship in the next release."
             exit 0
           fi
 

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,208 @@
+name: Reusable Auto Version (conventional commits)
+
+# Computes the next semver from conventional commits since the last tag,
+# creates the tag, and runs the AI release pipeline for it — so merging to
+# the default branch is the whole release process. Conventional-commit
+# hygiene is the contract: enforce it with commitlint.yml.
+#
+# The tag is created with the workflow's GITHUB_TOKEN, whose events never
+# trigger other workflows — release.yml is invoked directly as a nested
+# reusable workflow instead of relying on a tag-push trigger, so no PAT is
+# needed. A manually pushed tag still releases via the tag-push caller and
+# is picked up as the new baseline here; the two paths cannot double-release.
+
+on:
+  workflow_call:
+    inputs:
+      initial-version:
+        description: 'Version for the first release when no semver tag exists yet (without the v prefix)'
+        required: false
+        type: string
+        default: '0.1.0'
+      dry-run:
+        description: 'Compute and report the bump, but do not tag or release'
+        required: false
+        type: boolean
+        default: false
+      floating-tags:
+        description: >-
+          Advance floating vN / vN.M tags to the new release. Useful for
+          repos consumed at a floating ref (actions, reusable workflows);
+          leave off for apps.
+        required: false
+        type: boolean
+        default: false
+      model:
+        description: 'Claude model for release notes (forwarded to release.yml)'
+        required: false
+        type: string
+        default: 'claude-haiku-4-5'
+      draft:
+        description: 'Create as draft release (forwarded to release.yml)'
+        required: false
+        type: boolean
+        default: false
+      app-context:
+        description: 'End-user-facing app description for the what''s-new summary (forwarded to release.yml)'
+        required: false
+        type: string
+        default: ''
+      whats-new:
+        description: 'Generate whats-new.json + releases.json (forwarded to release.yml)'
+        required: false
+        type: boolean
+        default: true
+      auto-publish:
+        description: 'Publish the what''s-new summary without human review (forwarded to release.yml)'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key (pay-per-token). Optional if CLAUDE_CODE_OAUTH_TOKEN is set.'
+        required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: 'Claude Pro/Max OAuth token from `claude setup-token`. Preferred when set; billed to subscription.'
+        required: false
+    outputs:
+      tag:
+        description: 'The tag that was created and released (empty when nothing was releasable)'
+        value: ${{ jobs.version.outputs.tag }}
+      bump:
+        description: 'The computed bump: major, minor, patch, or none'
+        value: ${{ jobs.version.outputs.bump }}
+
+concurrency:
+  group: auto-version-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    name: Compute version bump
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
+      bump: ${{ steps.bump.outputs.bump }}
+    steps:
+      - name: Compute bump from conventional commits
+        id: bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          INITIAL: ${{ inputs.initial-version }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+
+          # Latest full-semver tag (floating vN / vN.M tags are ignored).
+          # The tags API needs no checkout and is constant-cost per tag.
+          LAST=$(gh api --paginate "repos/${REPO}/tags" --jq '.[].name' \
+            | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n 1)
+
+          if [ -z "$LAST" ]; then
+            BUMP="minor"
+            NEW="v${INITIAL}"
+            echo "No semver tag found — first release will be ${NEW}."
+          else
+            # Non-merge commit messages since the last tag. The compare API
+            # returns at most 250 commits; warn rather than misversion.
+            COMPARE=$(gh api "repos/${REPO}/compare/${LAST}...${SHA}")
+            TOTAL=$(echo "$COMPARE" | jq '.total_commits')
+            if [ "$TOTAL" -gt 250 ]; then
+              echo "::warning title=auto-version::${TOTAL} commits since ${LAST} but only 250 inspected — bump may be understated. Consider tagging manually."
+            fi
+            MESSAGES=$(echo "$COMPARE" \
+              | jq -r '.commits[] | select(.parents | length == 1) | .commit.message')
+            SUBJECTS=$(echo "$COMPARE" \
+              | jq -r '.commits[] | select(.parents | length == 1) | .commit.message | split("\n")[0]')
+
+            BUMP="none"
+            if printf '%s' "$SUBJECTS" | grep -qE '^[a-z]+(\([^)]*\))?!:' \
+               || printf '%s' "$MESSAGES" | grep -q 'BREAKING CHANGE'; then
+              BUMP="major"
+            elif printf '%s' "$SUBJECTS" | grep -qE '^feat(\([^)]*\))?:'; then
+              BUMP="minor"
+            elif printf '%s' "$SUBJECTS" | grep -qE '^(fix|perf|revert)(\([^)]*\))?:'; then
+              BUMP="patch"
+            fi
+
+            if [ "$BUMP" = "none" ]; then
+              echo "bump=none" >> "$GITHUB_OUTPUT"
+              echo "tag=" >> "$GITHUB_OUTPUT"
+              echo "::notice title=auto-version::No feat/fix/perf/breaking commits since ${LAST} — nothing to release."
+              exit 0
+            fi
+
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${LAST#v}"
+            case "$BUMP" in
+              major) NEW="v$((MAJOR + 1)).0.0" ;;
+              minor) NEW="v${MAJOR}.$((MINOR + 1)).0" ;;
+              patch) NEW="v${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            esac
+            echo "Bump since ${LAST}: ${BUMP} → ${NEW}"
+          fi
+
+          echo "bump=${BUMP}" >> "$GITHUB_OUTPUT"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "::notice title=auto-version::Dry run — would tag ${NEW} (${BUMP})."
+            exit 0
+          fi
+
+          gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${NEW}" -f sha="${SHA}" > /dev/null
+          echo "tag=${NEW}" >> "$GITHUB_OUTPUT"
+          echo "Created tag ${NEW} at ${SHA}."
+
+  release:
+    name: Release
+    needs: version
+    if: needs.version.outputs.tag != ''
+    # Pinned to @main rather than a relative path: relative nested refs
+    # resolve against the CALLER's repository, which for consumers would
+    # look for release.yml in their own repo.
+    uses: KotaHusky/cicd-toolkit/.github/workflows/release.yml@main
+    with:
+      tag: ${{ needs.version.outputs.tag }}
+      model: ${{ inputs.model }}
+      draft: ${{ inputs.draft }}
+      app-context: ${{ inputs.app-context }}
+      whats-new: ${{ inputs.whats-new }}
+      auto-publish: ${{ inputs.auto-publish }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  float-tags:
+    name: Advance floating major/minor tags
+    needs: [version, release]
+    if: inputs.floating-tags && needs.version.outputs.tag != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Shallow: HEAD is the release commit, which is all the floating tags
+      # need to point at. fetch-tags: true is fatal on tag-push events
+      # (actions/checkout#1467) and unnecessary here.
+      - uses: actions/checkout@v7
+
+      - name: Advance floating tags
+        shell: bash
+        run: |
+          # e.g. v2.5.4 → advance v2 and v2.5 to point at this commit
+          TAG="${{ needs.version.outputs.tag }}"
+          if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            MAJOR="v${BASH_REMATCH[1]}"
+            MINOR="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -fa "$MAJOR" -m "Update floating tag $MAJOR → $TAG"
+            git tag -fa "$MINOR" -m "Update floating tag $MINOR → $TAG"
+            git push origin "$MAJOR" "$MINOR" --force
+            echo "Advanced $MAJOR and $MINOR to $TAG"
+          else
+            echo "Tag $TAG is not a full semver patch; skipping floating tags."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ name: Reusable AI-Powered Release
 on:
   workflow_call:
     inputs:
+      tag:
+        description: >-
+          Tag to release (e.g. v2.6.0). Defaults to the triggering ref, which
+          is correct for tag-push callers; workflow-call chains that create
+          the tag themselves (e.g. auto-version.yml) must pass it explicitly.
+        required: false
+        type: string
+        default: ''
       model:
         description: 'Claude model for release notes and the what''s-new summary'
         required: false
@@ -96,7 +104,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          CURRENT_TAG="${{ github.ref_name }}"
+          CURRENT_TAG="${{ inputs.tag || github.ref_name }}"
           echo "current-tag=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
 
           # Find the previous semver tag (skip the current one) from the
@@ -441,7 +449,7 @@ jobs:
       - name: Validate, deny-list, and finalize summary
         run: |
           set -euo pipefail
-          TAG="${{ github.ref_name }}"
+          TAG="${{ inputs.tag || github.ref_name }}"
           VERSION="${TAG#v}"
           DATE=$(date -u +%Y-%m-%d)
           BODY_FILE=".whats-new-work/whats-new-body.json"
@@ -476,7 +484,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${{ github.ref_name }}"
+          TAG="${{ inputs.tag || github.ref_name }}"
 
           if [ "${{ inputs.auto-publish }}" != "true" ]; then
             cp /tmp/whats-new.json /tmp/whats-new.draft.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,11 @@ jobs:
         id: changelog
         env:
           GH_TOKEN: ${{ github.token }}
+          # Bound via env rather than interpolated into the script (script-
+          # injection hygiene; callers are trusted but the habit is cheap).
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          CURRENT_TAG="${{ inputs.tag || github.ref_name }}"
+          CURRENT_TAG="${RELEASE_TAG}"
           echo "current-tag=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
 
           # Find the previous semver tag (skip the current one) from the
@@ -447,9 +450,11 @@ jobs:
       # Common finalization for both auth paths: shape validation, the
       # mechanical deny-list gate, and composing version/date metadata.
       - name: Validate, deny-list, and finalize summary
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${RELEASE_TAG}"
           VERSION="${TAG#v}"
           DATE=$(date -u +%Y-%m-%d)
           BODY_FILE=".whats-new-work/whats-new-body.json"
@@ -483,8 +488,9 @@ jobs:
       - name: Publish what's-new assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${RELEASE_TAG}"
 
           if [ "${{ inputs.auto-publish }}" != "true" ]; then
             cp /tmp/whats-new.json /tmp/whats-new.draft.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,12 @@ jobs:
         with:
           egress-policy: audit
 
+      # Shallow on purpose: fetch-tags: true is fatal on tag-push events
+      # (actions/checkout#1467: "Cannot fetch both <sha> and refs/tags/X")
+      # and nothing here needs history — the previous tag comes from
+      # `git ls-remote` and the commit range from the compare API.
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          # Full history, which also fetches all tags via a wildcard refspec.
-          # fetch-tags: true with a shallow fetch is fatal on tag-push events
-          # (actions/checkout#1467: "Cannot fetch both <sha> and refs/tags/X").
-          fetch-depth: 0
 
       # OAuth preferred (one token across repos, subscription-billed);
       # API key is the curl fallback. The secrets context is not allowed in
@@ -100,8 +99,12 @@ jobs:
           CURRENT_TAG="${{ github.ref_name }}"
           echo "current-tag=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
 
-          # Find the previous semver tag (skip the current one)
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -n 1 || true)
+          # Find the previous semver tag (skip the current one) from the
+          # remote's ref advertisement — a few bytes per tag on any repo
+          # size, so the checkout can stay shallow with no tag fetch.
+          PREVIOUS_TAG=$(git ls-remote --tags origin \
+            | awk '{print $2}' | sed -e 's|^refs/tags/||' -e 's|\^{}$||' \
+            | sort -u -V | grep -vx "${CURRENT_TAG}" | tail -n 1 || true)
 
           if [ -n "$PREVIOUS_TAG" ]; then
             echo "Previous tag: ${PREVIOUS_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          fetch-tags: true
+          # Full history, which also fetches all tags via a wildcard refspec.
+          # fetch-tags: true with a shallow fetch is fatal on tag-push events
+          # (actions/checkout#1467: "Cannot fetch both <sha> and refs/tags/X").
+          fetch-depth: 0
 
       # OAuth preferred (one token across repos, subscription-billed);
       # API key is the curl fallback. The secrets context is not allowed in

--- a/.github/workflows/self-auto-version.yml
+++ b/.github/workflows/self-auto-version.yml
@@ -1,0 +1,23 @@
+name: Auto Version
+
+# Every merge to main computes a semver bump from the conventional commits
+# and, when releasable (feat/fix/perf/breaking), tags + releases + advances
+# the floating v2 / v2.x tags. Manual `v*.*.*` tag pushes (self-release.yml)
+# remain as the escape hatch and become the new baseline here.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  auto-version:
+    uses: ./.github/workflows/auto-version.yml
+    with:
+      floating-tags: true
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -23,11 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Shallow: HEAD is the tagged commit, which is all the floating tags
+      # need to point at. fetch-tags: true is fatal on tag-push events
+      # (actions/checkout#1467).
       - uses: actions/checkout@v7
-        with:
-          # fetch-tags: true with a shallow fetch is fatal on tag-push events
-          # (actions/checkout#1467); full depth fetches all tags safely.
-          fetch-depth: 0
 
       - name: Advance floating tags
         shell: bash

--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Full semver only — the floating v2 / v2.5 tags this workflow pushes
+      # must not trigger another (failing) release run for themselves.
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: write
@@ -21,9 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          fetch-tags: true
+          # fetch-tags: true with a shallow fetch is fatal on tag-push events
+          # (actions/checkout#1467); full depth fetches all tags safely.
+          fetch-depth: 0
 
       - name: Advance floating tags
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,12 @@ consumed by other repos. `examples/` holds copy-paste caller workflows for consu
 ## CDK Library & Releases
 - No barrel `lib/index.ts` — consumers deep-import from `lib/constructs/*` and
   `lib/stacks/*`. Don't add one.
-- Pushing a `v*` tag triggers `release.yml`, which calls the Anthropic API
-  (`ANTHROPIC_API_KEY` secret) to generate release notes. Only tag when cutting a release.
+- Releases are automatic: every merge to `main` runs `self-auto-version.yml`,
+  which computes the semver bump from the conventional commits (feat → minor,
+  fix/perf → patch, breaking → major; docs/chore/ci → no release), tags, and
+  runs the AI release pipeline. Commit types therefore decide versioning —
+  choose them deliberately. Manual `v*.*.*` tag pushes remain an escape hatch;
+  never tag manually unless intentionally cutting a release.
 
 ## Claude Tooling in This Repo
 - This repo hosts a Claude Code plugin marketplace (`.claude-plugin/marketplace.json`

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Bump rules (matching semantic-release defaults): `feat!:`/`BREAKING CHANGE` → 
 | Output | Description |
 |--------|-------------|
 | `tag` | The created tag, or empty when nothing was releasable |
-| `bump` | `major`, `minor`, `patch`, or `none` |
+| `bump` | `major`, `minor`, `patch`, `none`, or `retry` (re-release of an orphaned tag) |
 
 The tag is created with the run's `GITHUB_TOKEN`, whose events don't trigger other workflows — `release.yml` is invoked directly as a nested workflow, so no PAT is needed and a tag-push release workflow can coexist without double-releasing. Manual `v*.*.*` tags keep working as an escape hatch and become the new baseline for the next auto bump.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Bump rules (matching semantic-release defaults): `feat!:`/`BREAKING CHANGE` → 
 
 The tag is created with the run's `GITHUB_TOKEN`, whose events don't trigger other workflows — `release.yml` is invoked directly as a nested workflow, so no PAT is needed and a tag-push release workflow can coexist without double-releasing. Manual `v*.*.*` tags keep working as an escape hatch and become the new baseline for the next auto bump.
 
-If a release run fails after tagging (leaving a tag with no GitHub Release), the next run — including a manual full re-run — detects the orphan and re-releases that tag instead of computing a new bump (`bump: retry`); commits merged in the meantime ship in the following release.
+If a release run fails after tagging (leaving a tag with no GitHub Release), the next run — including a manual full re-run — detects the orphan and re-releases that tag instead of computing a new bump (`bump: retry`); commits merged in the meantime ship in the following release. The self-heal only fires in repos that already have at least one GitHub Release — adopting this workflow in a repo with plain unreleased git tags computes a normal bump from the latest tag rather than surprise-releasing it.
 
 > **Pinning caveat:** the nested `release.yml` call inside `auto-version.yml` is fixed at `@main` (GitHub can't parameterize `uses:`), so pinning `auto-version.yml` to a tag or SHA does **not** transitively pin the release pipeline. If you need a fully pinned release path, call `release.yml@<ref>` yourself from a tag-push workflow instead.
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ Bump rules (matching semantic-release defaults): `feat!:`/`BREAKING CHANGE` → 
 
 The tag is created with the run's `GITHUB_TOKEN`, whose events don't trigger other workflows — `release.yml` is invoked directly as a nested workflow, so no PAT is needed and a tag-push release workflow can coexist without double-releasing. Manual `v*.*.*` tags keep working as an escape hatch and become the new baseline for the next auto bump.
 
+If a release run fails after tagging (leaving a tag with no GitHub Release), the next run — including a manual full re-run — detects the orphan and re-releases that tag instead of computing a new bump (`bump: retry`); commits merged in the meantime ship in the following release.
+
+> **Pinning caveat:** the nested `release.yml` call inside `auto-version.yml` is fixed at `@main` (GitHub can't parameterize `uses:`), so pinning `auto-version.yml` to a tag or SHA does **not** transitively pin the release pipeline. If you need a fully pinned release path, call `release.yml@<ref>` yourself from a tag-push workflow instead.
+
 ### End-User What's-New Summaries
 
 Releases are **two-tier**: the GitHub Release body stays engineer-focused and specific, while `release.yml` additionally generates a plain-language, end-user-facing summary your app can display — a `whats-new.json` (latest) and cumulative `releases.json` (last 20) attached to each release as assets. The artifact contract is versioned (`schemaVersion: 1`) and published at [`schemas/whats-new.schema.json`](schemas/whats-new.schema.json).

--- a/README.md
+++ b/README.md
@@ -200,6 +200,40 @@ The workflow compares commits between the current and previous semver tags, send
 
 **Auth:** when `CLAUDE_CODE_OAUTH_TOKEN` is set it is preferred — generation runs via [claude-code-action](https://github.com/anthropics/claude-code-action) on your subscription (requires the [Claude GitHub App](https://github.com/apps/claude); note the action skips if the caller workflow file differs from the repo's default branch, so tag from a commit whose workflows match `main`). Otherwise `ANTHROPIC_API_KEY` is used via direct API calls. One of the two is required.
 
+### Automatic Versioning
+
+**`auto-version.yml`** — Make merging to `main` the whole release process: computes the next semver from [conventional commits](https://www.conventionalcommits.org/) since the last tag, creates the tag, and runs `release.yml` for it. Pair with `commitlint.yml` so commit messages are trustworthy.
+
+```yaml
+on:
+  push:
+    branches: [main]
+
+jobs:
+  auto-version:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/auto-version.yml@main
+    permissions:
+      contents: write
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+Bump rules (matching semantic-release defaults): `feat!:`/`BREAKING CHANGE` → major, `feat:` → minor, `fix:`/`perf:`/`revert:` → patch; anything else (docs, chore, ci, refactor, …) releases nothing. Merge commits are ignored.
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `initial-version` | string | `0.1.0` | First release when no semver tag exists yet |
+| `dry-run` | boolean | `false` | Report the computed bump without tagging or releasing |
+| `floating-tags` | boolean | `false` | Advance floating `vN` / `vN.M` tags after the release (for repos consumed at a floating ref; leave off for apps) |
+| `model` / `draft` / `app-context` / `whats-new` / `auto-publish` | — | — | Forwarded to `release.yml` (see above) |
+
+| Output | Description |
+|--------|-------------|
+| `tag` | The created tag, or empty when nothing was releasable |
+| `bump` | `major`, `minor`, `patch`, or `none` |
+
+The tag is created with the run's `GITHUB_TOKEN`, whose events don't trigger other workflows — `release.yml` is invoked directly as a nested workflow, so no PAT is needed and a tag-push release workflow can coexist without double-releasing. Manual `v*.*.*` tags keep working as an escape hatch and become the new baseline for the next auto bump.
+
 ### End-User What's-New Summaries
 
 Releases are **two-tier**: the GitHub Release body stays engineer-focused and specific, while `release.yml` additionally generates a plain-language, end-user-facing summary your app can display — a `whats-new.json` (latest) and cumulative `releases.json` (last 20) attached to each release as assets. The artifact contract is versioned (`schemaVersion: 1`) and published at [`schemas/whats-new.schema.json`](schemas/whats-new.schema.json).

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Bump rules (matching semantic-release defaults): `feat!:`/`BREAKING CHANGE` → 
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `initial-version` | string | `0.1.0` | First release when no semver tag exists yet |
+| `initial-version` | string | `0.1.0` | First release when no semver tag exists yet (fires only once a releasable commit is present — a `chore:`-only history releases nothing) |
 | `dry-run` | boolean | `false` | Report the computed bump without tagging or releasing |
 | `floating-tags` | boolean | `false` | Advance floating `vN` / `vN.M` tags after the release (for repos consumed at a floating ref; leave off for apps) |
 | `model` / `draft` / `app-context` / `whats-new` / `auto-publish` | — | — | Forwarded to `release.yml` (see above) |

--- a/examples/auto-version.yml
+++ b/examples/auto-version.yml
@@ -1,0 +1,36 @@
+# Automatic versioning + AI release on every merge to main.
+# Copy to .github/workflows/auto-version.yml in your repo.
+#
+# Computes the semver bump from conventional commits (feat → minor,
+# fix/perf → patch, breaking → major; anything else releases nothing),
+# creates the tag, and runs the AI release pipeline — release notes plus
+# the end-user whats-new.json assets. Pair with examples/ci.yml's
+# commitlint so commit messages are trustworthy.
+#
+# Alternative: keep examples/release.yml (manual tag push) if you want a
+# human to decide when releases happen. Both can coexist — a manual tag
+# releases via that path and becomes the baseline for the next auto bump.
+
+name: Auto Version
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-version:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/auto-version.yml@main
+    with:
+      # Optional: end-user-facing app description for the what's-new summary.
+      # Better: maintain .github/whats-new-context.md (see examples/whats-new-context.md).
+      app-context: ''
+      # Uncomment to require human review of the public summary before publish:
+      # auto-publish: false
+    secrets:
+      # Preferred: Claude Pro/Max OAuth token (claude setup-token), billed to subscription.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # Fallback: pay-per-token API key. Provide at least one of the two.
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/plugins/cicd-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cicd-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cicd-toolkit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Integrate KotaHusky/cicd-toolkit reusable GitHub Actions workflows, composite actions, and AWS CDK constructs into a consumer repo \u2014 workflow selection, secrets setup, and OIDC bootstrap.",
   "author": {
     "name": "KotaHusky"

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate-cicd-toolkit
-description: Integrate KotaHusky/cicd-toolkit reusable workflows and composite actions into the current repo — pick the right workflow, wire up the caller file, and set required secrets securely. Use when adding CI/CD (build verification, commitlint, Docker/GHCR, CDK deploys, static-site S3/CloudFront deploys, ECS Express deploys, AI-generated releases) to a repo that consumes cicd-toolkit.
+description: Integrate KotaHusky/cicd-toolkit reusable workflows and composite actions into the current repo — pick the right workflow, wire up the caller file, and set required secrets securely. Use when adding CI/CD (build verification, commitlint, Docker/GHCR, CDK deploys, static-site S3/CloudFront deploys, ECS Express deploys, automatic versioning, AI-generated releases) to a repo that consumes cicd-toolkit.
 ---
 
 # Integrate cicd-toolkit
@@ -33,9 +33,10 @@ Adapt the example rather than authoring a caller from scratch.
 | Deploy AWS CDK app (OIDC auth) | `cdk-deploy.yml` (synth-only check: `cdk-synth.yml`) |
 | Static site (Next.js/Astro/Vite) → S3 + CloudFront | `static-s3-deploy.yml` |
 | Node/Express app → ECS Fargate | `ecs-express-deploy.yml` / `ecs-express-app-deploy.yml` |
-| GitHub Release with AI-generated notes on `v*` tag | `release.yml` |
+| Automatic versioning + AI release on every merge to main (recommended) | `auto-version.yml` — computes the semver bump from conventional commits (no checkout, pure API), tags, and runs `release.yml`; pair with `commitlint.yml`. Caller needs `contents: write` |
+| GitHub Release with AI-generated notes on manual `v*` tag | `release.yml` |
 | Claude AI review on every PR (inline + sticky summary) | `claude-review.yml` — needs the [Claude GitHub App](https://github.com/apps/claude) installed and `ANTHROPIC_API_KEY` **or** `CLAUDE_CODE_OAUTH_TOKEN`; advisory by default (never blocks CI), `strict: true` to enforce |
-| Semver tag automation | `semver-tag.yml` |
+| Semver tag automation (tag only — does not chain to a release; prefer `auto-version.yml`) | `semver-tag.yml` |
 | End-user "what's new" panel in the app | `release.yml` (whats-new assets) + `whats-new-path` input on `static-s3-deploy.yml`/`docker-ghcr.yml` + `cicd-toolkit/lib/whats-new` — see the What's-New section below |
 | Azure Container Apps | `aca-provision.yml`, `aca-deploy.yml` |
 | Cloudflare DNS management | `cloudflare-dns.yml` |
@@ -119,10 +120,11 @@ reply.
 
 ## What's-New summaries (end-user release notes)
 
-`release.yml` produces two tiers on every `v*` tag: engineer-focused notes (the
-GitHub Release body) and a public, end-user-facing `whats-new.json` +
-`releases.json` (release assets) generated from a curated context file,
-sanitized by a redaction judge, and gated by a deny-list.
+`release.yml` produces two tiers on every release (auto via `auto-version.yml`
+or a manual `v*` tag): engineer-focused notes (the GitHub Release body) and a
+public, end-user-facing `whats-new.json` + `releases.json` (release assets)
+generated from a curated context file, sanitized by a redaction judge, and
+gated by a deny-list.
 
 **When wiring this up in a consumer repo:**
 
@@ -154,5 +156,8 @@ blocks publication if they ever appear in a summary.
 
 - Consumers pin `@main` — toolkit changes ship to this repo immediately on merge upstream. Pin a tag or SHA if the consumer needs stability.
 - Grant each caller job the `permissions:` block shown in the toolkit README for that workflow (OIDC deploys need `id-token: write`).
-- `release.yml` and `commitlint.yml` assume Conventional Commit messages.
+- `release.yml`, `auto-version.yml`, and `commitlint.yml` assume Conventional
+  Commit messages. With `auto-version.yml`, commit types decide versioning
+  (feat → minor, fix/perf → patch, breaking → major; docs/chore/ci release
+  nothing) — enforce them with `commitlint.yml` or versions will drift.
 - Verify by opening a small PR (or pushing a tag for release flows) and watching the run — reusable workflows can't be executed locally.


### PR DESCRIPTION
## Why

Versioning was manual (push a `v*` tag) and hasn't happened since v2.5.4 while 10 commits piled up — and the tag-automation piece that did exist (`semver-tag.yml`) was never chained to releases: its GITHUB_TOKEN-created tags can't trigger the tag-push release workflow, so it was a tag-only dead end. Closes #4.

## What

- **`auto-version.yml`** (new reusable): on merge to main, computes the bump from conventional commits since the last semver tag — **pure API, zero checkout**, constant cost on any repo size (per the fetch-cost concern on #75). `feat!:`/`BREAKING CHANGE` → major, `feat` → minor, `fix`/`perf`/`revert` → patch, everything else → no release. Creates the tag, then invokes `release.yml` as a **nested workflow call** (explicit chain — no PAT needed, and no double-release with the tag-push path). Inputs: `dry-run`, `initial-version`, `floating-tags`, plus pass-throughs (`model`/`draft`/`app-context`/`whats-new`/`auto-publish`). Outputs `tag` + `bump`.
- **`release.yml`**: new optional `tag` input (defaults to the triggering ref, so tag-push callers are unchanged).
- **`self-auto-version.yml`**: dogfoods it on this repo with `floating-tags: true` (replacing manual tagging; `self-release.yml` stays as the manual escape hatch and becomes the next baseline when used).
- **Docs**: README section, `examples/auto-version.yml`, CLAUDE.md release guidance, integrate skill (recommended row; `semver-tag.yml` marked tag-only/superseded), plugin → 0.4.0.

## Validated

Bump logic dry-run against this repo's live history: `v2.5.4` + 10 commits → **major → v3.0.0** (the range includes #52's intentional `feat!:`). YAML parses; 52/52 tests.

## Note

Stacked on #75 (release checkout fix) — merge #75 first and this diff shrinks to just the auto-version changes. First auto-release will fire on the first releasable merge after this lands and will be **v3.0.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)