### PR TITLE
fix(ecs-express): GHCR mirror source derived from github.repository, not hardcoded owner

### DIFF
--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -184,10 +184,16 @@ jobs:
         with:
           role-to-assume: ${{ secrets.role-arn }}
           aws-region: ${{ inputs.aws-region }}
+      # The image job (docker-ghcr.yml) pushes ghcr.io/{repository},
+      # lowercased — derive the same ref instead of hardcoding an owner or
+      # assuming the app slug matches the repo name.
+      - id: src
+        shell: bash
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
       - id: mirror
         uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@v2
         with:
-          source-image: ghcr.io/kotahusky/${{ inputs.app }}@${{ needs.image.outputs.digest }}
+          source-image: ${{ steps.src.outputs.image }}@${{ needs.image.outputs.digest }}
           ecr-repo: ${{ inputs.app }}
           ecr-tag: ${{ github.sha }}
           aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
Found while auditing docs coverage (#77): the ECS Express mirror job pulled `ghcr.io/kotahusky/{app}` while the image job it depends on pushes `ghcr.io/{repository}` (lowercased by metadata-action). Two bugs in one: broken for any consumer outside this owner (reusable-asset policy #71), and broken whenever the `app` slug differs from the repository name even inside it. The mirror now derives the identical ref the image job pushed, from `github.repository` lowercased.

Digest-pinned pull is unchanged — only the name the digest resolves under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)