### PR TITLE
fix(workflows): reference internal composite actions at @main

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref || github.ref }}
 
-      - uses: KotaHusky/cicd-toolkit/actions/turbo-setup@v2
+      - uses: KotaHusky/cicd-toolkit/actions/turbo-setup@main
         with:
           node-version: ${{ inputs.node-version }}
           pre-build-filter: ${{ inputs.pre-build-filter }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Recover stuck stacks
         if: inputs.recover-stacks && inputs.stack-prefix != ''
-        uses: KotaHusky/cicd-toolkit/actions/cfn-recover@v2
+        uses: KotaHusky/cicd-toolkit/actions/cfn-recover@main
         with:
           stack-prefix: ${{ inputs.stack-prefix }}
 

--- a/.github/workflows/cdk-synth.yml
+++ b/.github/workflows/cdk-synth.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: KotaHusky/cicd-toolkit/actions/turbo-setup@v2
+      - uses: KotaHusky/cicd-toolkit/actions/turbo-setup@main
         with:
           node-version: ${{ inputs.node-version }}
           pre-build-filter: ${{ inputs.pre-build-filter }}

--- a/.github/workflows/ecs-express-app-deploy.yml
+++ b/.github/workflows/ecs-express-app-deploy.yml
@@ -191,7 +191,7 @@ jobs:
         shell: bash
         run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
       - id: mirror
-        uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@v2
+        uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@main
         with:
           source-image: ${{ steps.src.outputs.image }}@${{ needs.image.outputs.digest }}
           ecr-repo: ${{ inputs.app }}

--- a/actions/cfn-recover/README.md
+++ b/actions/cfn-recover/README.md
@@ -18,7 +18,7 @@ Assumes AWS credentials are already configured (e.g. via `aws-actions/configure-
 ## Usage
 
 ```yaml
-- uses: KotaHusky/cicd-toolkit/actions/cfn-recover@v2
+- uses: KotaHusky/cicd-toolkit/actions/cfn-recover@main
   with:
     stack-prefix: MyProject-
 ```

--- a/actions/ecr-mirror/README.md
+++ b/actions/ecr-mirror/README.md
@@ -40,7 +40,7 @@ Assumes AWS credentials are already configured (e.g. via `aws-actions/configure-
   run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
 - id: mirror
-  uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@v2
+  uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@main
   with:
     source-image: ghcr.io/my-org/my-app@${{ needs.build.outputs.digest }}
     ecr-repo: my-app

--- a/actions/turbo-setup/README.md
+++ b/actions/turbo-setup/README.md
@@ -22,7 +22,7 @@ Composite action that installs Node.js, restores/saves `node_modules` from cache
 ## Usage
 
 ```yaml
-- uses: KotaHusky/cicd-toolkit/actions/turbo-setup@v2
+- uses: KotaHusky/cicd-toolkit/actions/turbo-setup@main
   with:
     node-version: '24'
     pre-build-filter: '@my-org/shared'


### PR DESCRIPTION
Part of moving all first-party repos to `@main` (latest): this repo's own workflows pinned its own composite actions (`turbo-setup`, `ecr-mirror`, `cfn-recover`) at `@v2`, so a merged action change didn't apply to the repo's own reusable workflows until a release — pure internal drift, since workflows and actions live and version together in this one repo. Consumers were already told `@main` in the README/examples; the action READMEs now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)