### PR TITLE
feat: pr-release-label.yml — label PRs with their semver release impact

### DIFF
--- a/.github/workflows/pr-release-label.yml
+++ b/.github/workflows/pr-release-label.yml
@@ -1,0 +1,122 @@
+name: Reusable PR Release Label
+
+# Labels a PR with the semver release impact merging it will cause —
+# `release:major` / `release:minor` / `release:patch` / `release:none` —
+# computed from the PR title with the same rules auto-version.yml applies
+# to commits. In squash-merge repos the PR title becomes the commit subject
+# auto-version.yml later inspects, so the label is an exact preview of the
+# release math. Pair with commitlint.yml so titles are trustworthy.
+#
+# Call from a pull_request-triggered workflow with types
+# [opened, edited, reopened] — `edited` so retitling re-labels; `synchronize`
+# is unnecessary (pushes don't change the title). The step is idempotent:
+# when the correct label is already present it makes no writes, so callers
+# whose CI triggers on `labeled` are only re-triggered when the impact
+# actually changes.
+#
+# Fork PRs: the pull_request token is read-only for forks, so labeling is
+# skipped (not failed) when the head repo differs from the base repo.
+
+on:
+  workflow_call:
+    inputs:
+      label-prefix:
+        description: 'Prefix for the four release-impact labels'
+        required: false
+        type: string
+        default: 'release:'
+    outputs:
+      bump:
+        description: 'The computed release impact: major, minor, patch, or none'
+        value: ${{ jobs.label.outputs.bump }}
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label release impact
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      bump: ${{ steps.apply.outputs.bump }}
+    steps:
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        with:
+          egress-policy: audit
+
+      - name: Compute and apply release-impact label
+        id: apply
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          PREFIX: ${{ inputs.label-prefix }}
+        run: |
+          set -euo pipefail
+
+          # Same rules as auto-version.yml: bang type or BREAKING CHANGE
+          # footer → major, feat → minor, fix/perf/revert → patch. The
+          # footer is matched line-anchored in the PR body so prose that
+          # merely mentions the phrase can't force a major.
+          BUMP="none"
+          if printf '%s' "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then
+            BUMP="major"
+          elif printf '%s' "${PR_BODY:-}" | grep -qE '^BREAKING[ -]CHANGE:'; then
+            BUMP="major"
+          elif printf '%s' "$PR_TITLE" | grep -qE '^feat(\([^)]*\))?:'; then
+            BUMP="minor"
+          elif printf '%s' "$PR_TITLE" | grep -qE '^(fix|perf|revert)(\([^)]*\))?:'; then
+            BUMP="patch"
+          fi
+          echo "bump=${BUMP}" >> "$GITHUB_OUTPUT"
+
+          if [ "$IS_FORK" = "true" ]; then
+            echo "::notice title=pr-release-label::Fork PR — token is read-only, skipping labels (impact: ${BUMP})."
+            exit 0
+          fi
+
+          case "$BUMP" in
+            major) COLOR="b60205"; DESC="Merging this PR causes a major release" ;;
+            minor) COLOR="0e8a16"; DESC="Merging this PR causes a minor release" ;;
+            patch) COLOR="fbca04"; DESC="Merging this PR causes a patch release" ;;
+            none)  COLOR="ededed"; DESC="Merging this PR causes no release" ;;
+          esac
+          WANT="${PREFIX}${BUMP}"
+
+          encode() { jq -rn --arg v "$1" '$v|@uri'; }
+
+          CURRENT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" --jq '.[].name')
+
+          # Idempotence: correct label already present and no stale
+          # siblings → no writes, so `labeled`-triggered CI isn't re-run.
+          STALE=""
+          for B in major minor patch none; do
+            L="${PREFIX}${B}"
+            if [ "$L" != "$WANT" ] && printf '%s\n' "$CURRENT" | grep -qxF "$L"; then
+              STALE="${STALE} ${L}"
+            fi
+          done
+          if [ -z "$STALE" ] && printf '%s\n' "$CURRENT" | grep -qxF "$WANT"; then
+            echo "Already labeled ${WANT} — nothing to do."
+            exit 0
+          fi
+
+          for L in $STALE; do
+            gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/$(encode "$L")" > /dev/null
+          done
+
+          # Create the label on first use so consumers need no setup.
+          if ! gh api "repos/${REPO}/labels/$(encode "$WANT")" > /dev/null 2>&1; then
+            gh api "repos/${REPO}/labels" \
+              -f name="$WANT" -f color="$COLOR" -f description="$DESC" > /dev/null
+          fi
+
+          if ! printf '%s\n' "$CURRENT" | grep -qxF "$WANT"; then
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" -f "labels[]=${WANT}" > /dev/null
+          fi
+          echo "Labeled #${PR_NUMBER} as ${WANT}."

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ to integrate all of it themselves.
   - [Environments, Promotion & Rollback](#environments-promotion--rollback)
   - [AI-Powered Release](#ai-powered-release)
   - [Automatic Versioning](#automatic-versioning)
+  - [PR Release Labels](#pr-release-labels)
   - [End-User What's-New Summaries](#end-user-whats-new-summaries)
   - [Claude Code Review](#claude-code-review)
   - [CI Doctor](#ci-doctor)
@@ -529,6 +530,36 @@ If a release run fails after tagging (leaving a tag with no GitHub Release), the
 > **Pinning caveat:** the nested `release.yml` call inside `auto-version.yml` is fixed at `@main` (GitHub can't parameterize `uses:`), so pinning `auto-version.yml` to a tag or SHA does **not** transitively pin the release pipeline. If you need a fully pinned release path, call `release.yml@<ref>` yourself from a tag-push workflow instead.
 
 **Tag-only variant:** `semver-tag.yml` is the lower-level workflow: it computes the conventional-commit bump and creates the `vX.Y.Z` tag (needs `contents: write`) but chains to **no** release — the caller wires downstream jobs off its outputs (`new-version`, `new-tag`, `bumped`, `changelog`) itself, as in [`examples/ecs-express.yml`](examples/ecs-express.yml). Its `default-bump` input (default `false` = no bump) can force a bump when no conventional commit calls for one. Prefer `auto-version.yml` unless you're composing the pipeline yourself.
+
+### PR Release Labels
+
+**`pr-release-label.yml`** — Labels every PR with the semver release impact merging it will cause — `release:major` / `release:minor` / `release:patch` / `release:none` — computed from the PR title with the **same rules `auto-version.yml` applies to commits**. In squash-merge repos the PR title becomes the commit subject the release math later inspects, so the label is an exact preview: reviewers see the version consequence before merging, and a mislabeled title (e.g. a `chore:` that should be a `feat:`) is caught at review time instead of at release time. Labels are created on first use — no repo setup needed.
+
+```yaml
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  release-label:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/pr-release-label.yml@main
+    permissions:
+      pull-requests: write
+```
+
+Include `edited` in the trigger so retitling a PR re-labels it; `synchronize` is unnecessary (pushes don't change the title). A `BREAKING CHANGE:` footer line in the PR body also promotes the label to major, matching the commit-footer rule.
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `label-prefix` | string | `release:` | Prefix for the four release-impact labels |
+
+| Output | Description |
+|--------|-------------|
+| `bump` | The computed release impact: `major`, `minor`, `patch`, or `none` |
+
+The step is idempotent — when the correct label is already present it makes no writes, so caller pipelines that trigger on `labeled` are only re-run when the impact actually changes. Fork PRs are skipped (not failed): the `pull_request` token is read-only for forks, so the impact is reported in the log only.
+
+> **Caveat:** the label previews the title's impact at merge time; the actual release bump is computed by `auto-version.yml` from **all** commits since the last tag, so a batch of merged PRs releases at the highest impact among them.
 
 ### End-User What's-New Summaries
 

--- a/examples/pr-release-label.yml
+++ b/examples/pr-release-label.yml
@@ -1,0 +1,16 @@
+# Labels every PR with the semver release impact merging it will cause
+# (release:major / minor / patch / none), matching auto-version.yml's math.
+# `edited` is in the trigger so retitling a PR re-labels it; `synchronize`
+# is unnecessary because pushes don't change the title.
+name: PR Labels
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  release-label:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/pr-release-label.yml@main


### PR DESCRIPTION
## Summary

New reusable workflow **`pr-release-label.yml`**: labels every PR with the semver release impact merging it will cause — `release:major` / `release:minor` / `release:patch` / `release:none` — computed from the conventional PR title with the **same rules `auto-version.yml` applies to commits**.

In squash-merge repos the PR title becomes the commit subject the release math later inspects, so the label is an exact preview: reviewers see the version consequence before merging, and a mislabeled title (a `chore:` that should be a `feat:`) is caught at review time instead of at release time.

## Behavior

- Bump rules mirror `auto-version.yml` exactly: bang type (`feat!:`) or line-anchored `BREAKING CHANGE:` footer in the PR body → major; `feat:` → minor; `fix:`/`perf:`/`revert:` → patch; anything else → none
- **Idempotent**: no API writes when the correct label is already present and no stale siblings exist — caller pipelines that trigger on `labeled` are only re-run when the impact actually changes
- Labels are created on first use (color + description) — zero repo setup
- Fork PRs are skipped, not failed (the `pull_request` token is read-only for forks); the impact is still reported in the log
- Untrusted PR title/body are passed via `env`, never interpolated into the script
- `bump` output exposed for callers that want to gate on it
- Caller triggers on `[opened, edited, reopened]` — `edited` so retitling re-labels; `synchronize` is unnecessary since pushes don't change the title

## Included

- `.github/workflows/pr-release-label.yml` — the reusable workflow (harden-runner, `set -euo pipefail`, no checkout needed)
- `examples/pr-release-label.yml` — copy-paste caller
- README: new "PR Release Labels" section + ToC entry, with the batch-merge caveat (the actual release bump is computed from all commits since the last tag, so a batch releases at the highest impact among them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)