### PR TITLE
fix(release): never block the release on missing Anthropic credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       release-url: ${{ steps.create-release.outputs.release-url }}
+      ai-mode: ${{ steps.auth.outputs.mode }}
     steps:
       - name: Harden runner (egress audit)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
@@ -83,7 +84,9 @@ jobs:
 
       # OAuth preferred (one token across repos, subscription-billed);
       # API key is the curl fallback. The secrets context is not allowed in
-      # step-level if:, so resolve the mode once here.
+      # step-level if:, so resolve the mode once here. Missing credentials
+      # never block the release: mode=none warns and takes the degraded
+      # path (GitHub-generated notes only, what's-new skipped).
       - name: Resolve Anthropic credentials
         id: auth
         env:
@@ -95,8 +98,8 @@ jobs:
           elif [ -n "${ANTHROPIC_API_KEY}" ]; then
             echo "mode=api-key" >> "$GITHUB_OUTPUT"
           else
-            echo "::error title=release::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY was provided. Pass one via 'secrets:' (or 'secrets: inherit')."
-            exit 1
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            echo "::warning title=release::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY was provided — creating the release with GitHub-generated notes only (no AI title/summary; the what's-new summary is skipped). Pass one via 'secrets:' (or 'secrets: inherit') to enable AI release notes."
           fi
 
       - name: Gather changelog
@@ -226,22 +229,31 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.changelog.outputs.current-tag }}"
-          if [ ! -s .release-work/title.txt ] || [ ! -s .release-work/summary.txt ]; then
-            echo "::error title=release::Release notes were not generated. If using CLAUDE_CODE_OAUTH_TOKEN, check the Claude CLI step logs; or pass ANTHROPIC_API_KEY instead."
-            exit 1
-          fi
-          TITLE=$(cat .release-work/title.txt)
-          SUMMARY=$(cat .release-work/summary.txt)
-          # The AI summary is composed from the commit log and can echo
-          # @handles or #123 tokens from it — code-span such tokens so they
-          # can't become live mentions/autolinks (same class as the
-          # changelog fix below). Existing backticks are stripped first so
-          # the inserted spans stay valid.
-          SUMMARY=$(printf '%s' "$SUMMARY" | tr -d '\140' \
-            | sed -E -e 's/(^|[^[:alnum:]])@([A-Za-z0-9][A-Za-z0-9-]*)/\1`@\2`/g' \
-                     -e 's/(^|[^[:alnum:]])#([0-9]+)/\1`#\2`/g')
+          if [ "${{ steps.auth.outputs.mode }}" = "none" ]; then
+            # Degraded path (no Anthropic credentials): the release still
+            # ships — tag-only title, GitHub-generated notes for the body.
+            SUMMARY=""
+            RELEASE_TITLE="${TAG}"
+          else
+            # Credentials were present, so a missing/empty notes file is a
+            # real generation failure worth stopping on.
+            if [ ! -s .release-work/title.txt ] || [ ! -s .release-work/summary.txt ]; then
+              echo "::error title=release::Release notes were not generated. If using CLAUDE_CODE_OAUTH_TOKEN, check the Claude CLI step logs; or pass ANTHROPIC_API_KEY instead."
+              exit 1
+            fi
+            TITLE=$(cat .release-work/title.txt)
+            SUMMARY=$(cat .release-work/summary.txt)
+            # The AI summary is composed from the commit log and can echo
+            # @handles or #123 tokens from it — code-span such tokens so they
+            # can't become live mentions/autolinks (same class as the
+            # changelog fix below). Existing backticks are stripped first so
+            # the inserted spans stay valid.
+            SUMMARY=$(printf '%s' "$SUMMARY" | tr -d '\140' \
+              | sed -E -e 's/(^|[^[:alnum:]])@([A-Za-z0-9][A-Za-z0-9-]*)/\1`@\2`/g' \
+                       -e 's/(^|[^[:alnum:]])#([0-9]+)/\1`#\2`/g')
 
-          RELEASE_TITLE="${TAG} — ${TITLE}"
+            RELEASE_TITLE="${TAG} — ${TITLE}"
+          fi
 
           # GitHub's generated notes provide the PR-level "What's Changed"
           # list, the Full Changelog compare link, and contributor credit
@@ -276,7 +288,11 @@ jobs:
             echo "::notice title=release::Generated notes contain no PR entries — including the commit-level changelog."
             SAFE_NOTES=$(printf '## Changelog\n\n%s\n\n%s' "$(cat /tmp/changelog.txt)" "$SAFE_NOTES")
           fi
-          RELEASE_BODY=$(printf '%s\n\n%s' "$SUMMARY" "$SAFE_NOTES")
+          if [ -n "$SUMMARY" ]; then
+            RELEASE_BODY=$(printf '%s\n\n%s' "$SUMMARY" "$SAFE_NOTES")
+          else
+            RELEASE_BODY="$SAFE_NOTES"
+          fi
 
           DRAFT_FLAG=""
           if [ "${{ inputs.draft }}" = "true" ]; then
@@ -293,7 +309,7 @@ jobs:
           echo "Release created: ${RELEASE_URL}"
 
       - name: Upload changelog artifact
-        if: ${{ inputs.whats-new }}
+        if: ${{ inputs.whats-new && steps.auth.outputs.mode != 'none' }}
         uses: actions/upload-artifact@v7
         with:
           name: release-changelog
@@ -307,7 +323,10 @@ jobs:
   whats-new:
     name: What's-New Summary
     needs: release
-    if: ${{ inputs.whats-new }}
+    # Also skipped when no Anthropic credentials reached the release job
+    # (ai-mode 'none') — the release itself still ships via its degraded
+    # path, and that job already emitted the warning annotation.
+    if: ${{ inputs.whats-new && needs.release.outputs.ai-mode != 'none' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/README.md
+++ b/README.md
@@ -479,8 +479,8 @@ jobs:
 
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `CLAUDE_CODE_OAUTH_TOKEN` | one of | Claude Pro/Max OAuth token from `claude setup-token` — preferred; billed to subscription |
-| `ANTHROPIC_API_KEY` | one of | Anthropic API key — pay-per-token fallback |
+| `CLAUDE_CODE_OAUTH_TOKEN` | optional | Claude Pro/Max OAuth token from `claude setup-token` — preferred; billed to subscription |
+| `ANTHROPIC_API_KEY` | optional | Anthropic API key — pay-per-token fallback |
 
 | Output | Description |
 |--------|-------------|
@@ -488,7 +488,7 @@ jobs:
 
 The workflow compares commits between the current and previous semver tags, sends the log to Claude, and creates a release titled `v1.2.0 — <AI-generated title>` whose body is the AI summary plus GitHub's generated "What's Changed" (PR-level changelog, Full Changelog compare link, and contributor credit). Mention-safe by construction: PR titles and any `@`/`#` tokens the summary echoes are code-spanned, so release notes can never @-mention unrelated users; the `by @author` attributions are the one intentional mention, driving the release's Contributors section. The commit-level changelog feeds the AI and (when `whats-new` is on) is uploaded as a run artifact rather than duplicated in the body.
 
-**Auth:** when `CLAUDE_CODE_OAUTH_TOKEN` is set it is preferred — generation runs via the Claude Code CLI on your subscription (no GitHub App needed for releases; the CLI works on any trigger, including tag pushes and `auto-version.yml`'s main pushes). Otherwise `ANTHROPIC_API_KEY` is used via direct API calls. One of the two is required.
+**Auth:** when `CLAUDE_CODE_OAUTH_TOKEN` is set it is preferred — generation runs via the Claude Code CLI on your subscription (no GitHub App needed for releases; the CLI works on any trigger, including tag pushes and `auto-version.yml`'s main pushes). Otherwise `ANTHROPIC_API_KEY` is used via direct API calls. Missing credentials never block the release: with neither secret the workflow emits a warning annotation and still creates the release — title is just the tag, body is GitHub's generated notes, and the what's-new job is skipped.
 
 ### Automatic Versioning
 

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -14,7 +14,9 @@ jobs:
     permissions:
       contents: write
     secrets:
-      # One of the two is required. OAuth token preferred (subscription-billed,
+      # Both optional — with neither, the release is still created from
+      # GitHub-generated notes (a warning is emitted; AI title/summary and
+      # what's-new are skipped). OAuth token preferred (subscription-billed,
       # from `claude setup-token`; requires the Claude GitHub App on the repo).
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # pay-per-token fallback

--- a/plugins/cicd-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cicd-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cicd-toolkit",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Integrate KotaHusky/cicd-toolkit reusable GitHub Actions workflows, composite actions, and AWS CDK constructs into a consumer repo \u2014 workflow selection, secrets setup, and OIDC bootstrap.",
   "author": {
     "name": "KotaHusky"

--- a/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
+++ b/plugins/cicd-toolkit/skills/integrate-cicd-toolkit/SKILL.md
@@ -64,7 +64,7 @@ Composite actions (`turbo-setup`, `ecr-mirror`, `cfn-recover`) are referenced as
 Determine which secrets the chosen workflow needs (from the fetched README). Common ones:
 
 - `AWS_DEPLOY_ROLE_ARN` — for any AWS deploy workflow; produced by the OIDC bootstrap (see the `bootstrap-oidc` skill). No static AWS keys, ever.
-- `ANTHROPIC_API_KEY` — for `release.yml` AI release notes.
+- `ANTHROPIC_API_KEY` — for `release.yml` AI release notes. Optional: with no Anthropic credential at all, `release.yml` still creates the release from GitHub-generated notes (warning annotation; AI notes and what's-new skipped).
 - `TURBO_TOKEN` / `TURBO_TEAM` — optional, Turbo remote cache.
 - `NODE_AUTH_TOKEN` — optional, private GitHub Packages during builds.
 


### PR DESCRIPTION
## Problem

When neither `CLAUDE_CODE_OAUTH_TOKEN` nor `ANTHROPIC_API_KEY` reaches `release.yml`, the release job hard-fails at the credential-resolve step:

```
Error: Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY was provided. Pass one via 'secrets:' (or 'secrets: inherit').
Error: Process completed with exit code 1.
```

Missing AI credentials should never block a release — every other workflow in the toolkit (`build-verify.yml`, `ci-doctor.yml`) already degrades gracefully in this case.

## Change

- **Resolve Anthropic credentials** now emits `mode=none` plus a `::warning` annotation instead of `::error` + `exit 1` (same pattern as `ci-doctor.yml`).
- **Create GitHub Release** takes a degraded path on `mode=none`: title is just the tag, body is GitHub's generated "What's Changed" notes, no AI summary. The hard error is kept only for the case where credentials *were* present but note generation failed — that's a real failure worth stopping on.
- The **what's-new job** is skipped via a new `ai-mode` job output (`inputs.whats-new && needs.release.outputs.ai-mode != 'none'`); previously it would have fallen into the API-key path with an empty key and failed at the curl call. The changelog artifact upload that only feeds it is skipped too.
- Docs: README secrets table + Auth paragraph, `examples/release.yml` comment, and the `integrate-cicd-toolkit` skill now describe both secrets as optional; plugin version bumped to 0.7.1 per repo policy.

## Verification

- YAML parses; `bash -n` passes on every `run:` script in the workflow (with `${{ }}` interpolations stubbed).
- Root vitest suite: 80/80 passing.
- Consumer-facing behavior with credentials present is unchanged (oauth/api-key paths untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)