### PR TITLE
fix(ci-doctor): set GH_REPO so gh works without a checkout

### DIFF
--- a/.github/workflows/ci-doctor.yml
+++ b/.github/workflows/ci-doctor.yml
@@ -47,6 +47,10 @@ jobs:
     timeout-minutes: 5
     env:
       GH_TOKEN: ${{ github.token }}
+      # gh needs the repo explicitly: this job has no actions/checkout, so without
+      # GH_REPO it falls back to reading a git remote and dies with
+      # "fatal: not a git repository". github.repository is the CALLER's repo.
+      GH_REPO: ${{ github.repository }}
       WORKFLOW_NAME: ${{ inputs.workflow-name }}
       RUN_ID: ${{ inputs.run-id }}
     steps:
@@ -85,6 +89,8 @@ jobs:
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
+      # Explicit repo for gh (see heal job) — don't rely on the checkout below.
+      GH_REPO: ${{ github.repository }}
       WORKFLOW_NAME: ${{ inputs.workflow-name }}
       RUN_ID: ${{ inputs.run-id }}
       MAX_LOG_LINES: ${{ inputs.max-log-lines }}


### PR DESCRIPTION
## Problem

The **heal** job (`if: inputs.conclusion == 'success'` — closes stale ci-doctor tracking issues once CI is green again) has **no `actions/checkout`**. So its `gh issue list` had no repo context and fell back to reading a git remote, dying with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Effect in consumer repos: **every successful deploy** produced a red **CI Doctor** run — the "everything's fine, close the alert" path was the broken one, which reads like deploys are failing when they aren't. (Seen in `KotaHusky/den` after a batch of merges.)

## Fix

Set `GH_REPO: ${{ github.repository }}` on both jobs' `env:`. In a reusable (`workflow_call`) workflow, `github.repository` is the **caller's** repo — exactly the repo whose issues the doctor manages (already used for `RUN_URL`). `gh` reads `GH_REPO` directly, so it no longer depends on an implicit checkout.

Added to the `diagnose` job too (which *does* check out) so `gh` there is likewise checkout-independent — hardening against the same class of bug.

## Scope

One env line per job; no behavior change beyond making `gh` resolve the repo explicitly. Consumers tracking `@main` (e.g. `den`'s `ci-doctor.yml`) pick this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)