### PR TITLE
feat: scope OIDC deploy roles by repo + minimal modern-bootstrap policy

### DIFF
--- a/bin/bootstrap.ts
+++ b/bin/bootstrap.ts
@@ -5,174 +5,129 @@ import { OidcBootstrapStack } from '../lib/stacks/oidc-bootstrap-stack';
 
 const app = new cdk.App();
 
+// Every repo's deploy role, defined once. Use `-c repos=<a,b>` to select which
+// roles to create in the CURRENT target account (CDK_DEFAULT_ACCOUNT); omit to
+// create all. Scoping matters now that workloads live in separate accounts: a
+// bootstrap run should not mint a repo's deploy role in an account that repo
+// never deploys to.
+const allRoles = [
+  {
+    repo: 'telegram-bot',
+    roleName: 'TelegramBotDeployRole',
+    policies: [
+      new iam.PolicyStatement({
+        actions: ['cloudformation:*'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        actions: ['s3:*'],
+        resources: ['arn:aws:s3:::cdk-*', 'arn:aws:s3:::cdk-*/*'],
+      }),
+      new iam.PolicyStatement({
+        actions: ['lambda:*'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        actions: ['apigateway:*'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        actions: ['dynamodb:*'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        actions: [
+          'iam:CreateRole', 'iam:DeleteRole', 'iam:GetRole', 'iam:PassRole',
+          'iam:AttachRolePolicy', 'iam:DetachRolePolicy',
+          'iam:PutRolePolicy', 'iam:DeleteRolePolicy', 'iam:GetRolePolicy',
+          'iam:TagRole', 'iam:UntagRole',
+        ],
+        resources: [
+          'arn:aws:iam::*:role/TelegramBot-*',
+          'arn:aws:iam::*:role/cdk-*',
+        ],
+      }),
+      new iam.PolicyStatement({
+        actions: ['ssm:GetParameter', 'ssm:PutParameter', 'ssm:DeleteParameter'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        actions: ['cloudwatch:*', 'logs:*'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        actions: ['ecr:*'],
+        resources: ['*'],
+      }),
+    ],
+  },
+  {
+    repo: 'kinky-connections-app',
+    branch: '*',
+    roleName: 'KinkyConnections-GitHubDeploy',
+    // Modern-bootstrap deploy: standard `cdk deploy` assumes the bootstrap
+    // `cdk-*` roles (deploy / file-publishing / image-publishing / lookup),
+    // which hold the actual resource-mutation permissions (the CloudFormation
+    // execution role runs with AdministratorAccess). So the GitHub role needs
+    // only to ASSUME those roles, plus the few direct AWS calls the CI workflow
+    // makes outside CloudFormation (stack-status reads, SSM param reads, and the
+    // post-deploy CloudFront invalidation). This is a much smaller trust surface
+    // than the previous `--method=direct` policy (which required enumerating
+    // every service the app provisions).
+    policies: [
+      new iam.PolicyStatement({
+        sid: 'AssumeCdkBootstrapRoles',
+        actions: ['sts:AssumeRole'],
+        resources: ['arn:aws:iam::*:role/cdk-*'],
+      }),
+      new iam.PolicyStatement({
+        sid: 'CdkStackStatusReads',
+        // ListStacks is account-scoped (no resource-level perms); DescribeStacks
+        // is used for deploy status + reading outputs.
+        actions: ['cloudformation:DescribeStacks', 'cloudformation:ListStacks'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        sid: 'PostDeployReadsAndInvalidation',
+        actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+        resources: [
+          'arn:aws:ssm:*:*:parameter/KinkyConnections/*',
+          'arn:aws:ssm:*:*:parameter/KinkyConnectionsDev/*',
+          'arn:aws:ssm:*:*:parameter/kinky-connections/*',
+        ],
+      }),
+      new iam.PolicyStatement({
+        sid: 'CloudFrontInvalidation',
+        actions: ['cloudfront:CreateInvalidation', 'cloudfront:GetInvalidation'],
+        resources: ['arn:aws:cloudfront::*:distribution/*'],
+      }),
+    ],
+  },
+];
+
+const reposCtx = app.node.tryGetContext('repos');
+const selectedRepos = reposCtx
+  ? String(reposCtx).split(',').map((r) => r.trim()).filter(Boolean)
+  : null;
+const roles = selectedRepos
+  ? allRoles.filter((r) => selectedRepos.includes(r.repo))
+  : allRoles;
+
+if (roles.length === 0) {
+  throw new Error(
+    `No roles matched -c repos=${reposCtx}. Known repos: ${allRoles.map((r) => r.repo).join(', ')}`,
+  );
+}
+
 new OidcBootstrapStack(app, 'OidcBootstrapStack', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1',
   },
   githubOrg: 'KotaHusky',
-  roles: [
-    {
-      repo: 'telegram-bot',
-      roleName: 'TelegramBotDeployRole',
-      policies: [
-        new iam.PolicyStatement({
-          actions: ['cloudformation:*'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['s3:*'],
-          resources: ['arn:aws:s3:::cdk-*', 'arn:aws:s3:::cdk-*/*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['lambda:*'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['apigateway:*'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['dynamodb:*'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: [
-            'iam:CreateRole', 'iam:DeleteRole', 'iam:GetRole', 'iam:PassRole',
-            'iam:AttachRolePolicy', 'iam:DetachRolePolicy',
-            'iam:PutRolePolicy', 'iam:DeleteRolePolicy', 'iam:GetRolePolicy',
-            'iam:TagRole', 'iam:UntagRole',
-          ],
-          resources: [
-            'arn:aws:iam::*:role/TelegramBot-*',
-            'arn:aws:iam::*:role/cdk-*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['ssm:GetParameter', 'ssm:PutParameter', 'ssm:DeleteParameter'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['cloudwatch:*', 'logs:*'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['ecr:*'],
-          resources: ['*'],
-        }),
-      ],
-    },
-    {
-      repo: 'kinky-connections-app',
-      branch: '*',
-      roleName: 'KinkyConnections-GitHubDeploy',
-      // Codifies the live GitHubDeployDirectResourceOps inline policy so a
-      // re-bootstrap doesn't silently drop it (this repo deploys --method=direct).
-      directDeployResourceOps: true,
-      policies: [
-        new iam.PolicyStatement({
-          actions: ['cloudformation:*'],
-          resources: [
-            'arn:aws:cloudformation:*:*:stack/KinkyConnections-*/*',
-            'arn:aws:cloudformation:*:*:stack/KinkyConnectionsDev-*/*',
-            'arn:aws:cloudformation:*:*:stack/cdk-*/*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['s3:*'],
-          resources: [
-            'arn:aws:s3:::kinkyconnections-*', 'arn:aws:s3:::kinkyconnections-*/*',
-            'arn:aws:s3:::cdk-*', 'arn:aws:s3:::cdk-*/*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['dynamodb:*'],
-          resources: [
-            'arn:aws:dynamodb:*:*:table/KinkyConnections-*',
-            'arn:aws:dynamodb:*:*:table/KinkyConnectionsDev-*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['cognito-idp:*'],
-          resources: ['arn:aws:cognito-idp:*:*:userpool/*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['lambda:*'],
-          resources: [
-            'arn:aws:lambda:*:*:function:KinkyConnections-*',
-            'arn:aws:lambda:*:*:function:KinkyConnectionsDev-*',
-            'arn:aws:lambda:*:*:function:kinky-connections-*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['apigateway:*'],
-          resources: ['arn:aws:apigateway:*::/apis*', 'arn:aws:apigateway:*::/tags*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['apprunner:*'],
-          resources: [
-            'arn:aws:apprunner:*:*:service/KinkyConnections-*/*',
-            'arn:aws:apprunner:*:*:service/KinkyConnectionsDev-*/*',
-            'arn:aws:apprunner:*:*:service/kinky-connections-*/*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['ecr:GetAuthorizationToken'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: [
-            'ecr:CreateRepository', 'ecr:DescribeRepositories', 'ecr:PutLifecyclePolicy',
-            'ecr:BatchCheckLayerAvailability', 'ecr:InitiateLayerUpload',
-            'ecr:UploadLayerPart', 'ecr:CompleteLayerUpload', 'ecr:PutImage',
-            'ecr:BatchGetImage', 'ecr:GetDownloadUrlForLayer',
-          ],
-          resources: ['arn:aws:ecr:*:*:repository/kinky-connections-*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['cloudfront:*'],
-          resources: ['arn:aws:cloudfront::*:distribution/*'],
-        }),
-        new iam.PolicyStatement({
-          actions: ['cloudwatch:*', 'logs:*', 'xray:*'],
-          resources: ['*'],
-        }),
-        new iam.PolicyStatement({
-          actions: [
-            'iam:CreateRole', 'iam:DeleteRole', 'iam:GetRole', 'iam:PassRole',
-            'iam:AttachRolePolicy', 'iam:DetachRolePolicy',
-            'iam:PutRolePolicy', 'iam:DeleteRolePolicy', 'iam:GetRolePolicy',
-            'iam:TagRole', 'iam:UntagRole', 'iam:ListRolePolicies', 'iam:ListAttachedRolePolicies',
-          ],
-          resources: [
-            'arn:aws:iam::*:role/KinkyConnections-*',
-            'arn:aws:iam::*:role/KinkyConnectionsDev-*',
-            'arn:aws:iam::*:role/cdk-*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['ssm:GetParameter', 'ssm:GetParameters', 'ssm:PutParameter', 'ssm:DeleteParameter'],
-          resources: [
-            'arn:aws:ssm:*:*:parameter/KinkyConnections/*',
-            'arn:aws:ssm:*:*:parameter/KinkyConnectionsDev/*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['secretsmanager:*'],
-          resources: [
-            'arn:aws:secretsmanager:*:*:secret:KinkyConnections-*',
-            'arn:aws:secretsmanager:*:*:secret:KinkyConnectionsDev-*',
-          ],
-        }),
-        new iam.PolicyStatement({
-          actions: ['sts:AssumeRole'],
-          resources: ['arn:aws:iam::*:role/cdk-*'],
-        }),
-      ],
-    },
-  ],
+  roles,
 });


### PR DESCRIPTION
## What
- **`-c repos=<a,b>` role selection** in `bin/bootstrap.ts` — a bootstrap run now only creates the named repos' deploy roles in the current target account (`CDK_DEFAULT_ACCOUNT`). Omit the flag for the previous behaviour (all roles).
- **Minimal modern-bootstrap policy** for one workload's deploy role — standard `cdk deploy` assumes the bootstrap `cdk-*` roles (which carry the real mutation permissions via the CloudFormation execution role), so the federated GitHub role only needs `sts:AssumeRole` on `cdk-*` plus stack-status reads, SSM parameter reads, and CloudFront invalidation.

## Why
Workloads now live in **separate accounts**. Without `-c repos=`, bootstrapping account A would mint deploy roles for repos that only ever deploy to account B — an unnecessary cross-repo trust grant. Selection keeps each account's trust surface to exactly the repos that deploy there.

The minimal policy is both **smaller** (no enumeration of every provisioned service) and **more robust** (new services need no policy change — the `cdk-*` execution role already covers them) than the previous `--method=direct` inline policy.

## Compatibility
`-c repos=` is optional and defaults to all roles, so existing single-account bootstraps are unchanged. The refreshed role assumes standard `cdk deploy` (not `--method=direct`); consumers using that role must deploy with the default method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)